### PR TITLE
Fix launcher sizing and prefer external mirror cameras

### DIFF
--- a/trace/Services/MirrorManager.swift
+++ b/trace/Services/MirrorManager.swift
@@ -123,7 +123,7 @@ final class MirrorManager {
         let session = AVCaptureSession()
         session.beginConfiguration()
 
-        guard let camera = AVCaptureDevice.default(for: .video) else {
+        guard let camera = preferredCamera() else {
             session.commitConfiguration()
             throw MirrorError.noCamera
         }
@@ -139,6 +139,20 @@ final class MirrorManager {
 
         session.commitConfiguration()
         return session
+    }
+
+    private func preferredCamera() -> AVCaptureDevice? {
+        let discoverySession = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.external, .builtInWideAngleCamera],
+            mediaType: .video,
+            position: .unspecified
+        )
+
+        if let externalCamera = discoverySession.devices.first(where: { $0.deviceType == .external }) {
+            return externalCamera
+        }
+
+        return discoverySession.devices.first ?? AVCaptureDevice.default(for: .video)
     }
 
     private func configureUserSelectedVideoEffects(for camera: AVCaptureDevice) {

--- a/trace/Views/LauncherView.swift
+++ b/trace/Views/LauncherView.swift
@@ -189,6 +189,10 @@ struct LauncherView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .launcherWindowWillHide)) { _ in
             cancelUsageSampling()
+            clearSearch()
+        }
+        .onChange(of: results.count) { _, _ in
+            notifyContentSizeDidChange()
         }
         .onDisappear {
             currentSearchTask?.cancel()
@@ -196,7 +200,6 @@ struct LauncherView: View {
             cancellables.removeAll()
         }
         .onKeyPress(.escape) {
-            clearSearch()
             onClose()
             return .handled
         }
@@ -224,6 +227,12 @@ struct LauncherView: View {
                 selectedActionIndex = (selectedActionIndex + 1) % actionCount
             }
             return .handled
+        }
+    }
+
+    private func notifyContentSizeDidChange() {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .launcherContentSizeDidChange, object: nil)
         }
     }
 }

--- a/trace/Windows/LauncherWindow.swift
+++ b/trace/Windows/LauncherWindow.swift
@@ -137,8 +137,8 @@ class LauncherWindow: NSPanel {
         logger.debug("🙈 LauncherWindow.hide() called with restoreFocus: \(restoreFocus)")
         
         preventAutoClose = false // Reset flag when hiding
-        NotificationCenter.default.post(name: .launcherWindowWillHide, object: self)
         orderOut(nil)
+        NotificationCenter.default.post(name: .launcherWindowWillHide, object: self)
         
         // Only restore focus to the previously active application if requested
         if restoreFocus, let lastApp = PermissionManager.shared.lastActiveApplication {
@@ -162,10 +162,17 @@ class LauncherWindow: NSPanel {
             name: NSWindow.didMoveNotification,
             object: self
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(launcherContentSizeDidChange),
+            name: .launcherContentSizeDidChange,
+            object: nil
+        )
     }
     
     private func positionOnScreen() {
         guard let screen = NSScreen.main else { return }
+        resizeToFitContent()
         
         let nextFrame = frame(
             on: screen,
@@ -193,6 +200,37 @@ class LauncherWindow: NSPanel {
         }
         
         schedulePositionSave(for: constrainedFrame, on: screen)
+    }
+
+    @objc private func launcherContentSizeDidChange() {
+        guard isVisible else { return }
+        guard let screen = screen ?? NSScreen.main else { return }
+
+        let previousMaxY = frame.maxY
+        savePositionWorkItem?.cancel()
+        isApplyingSavedPosition = true
+
+        resizeToFitContent()
+        var nextFrame = horizontallyCenteredFrame(frame, on: screen)
+        nextFrame.origin.y = clamp(
+            previousMaxY - nextFrame.height,
+            min: screen.visibleFrame.minY,
+            max: screen.visibleFrame.maxY - nextFrame.height
+        )
+
+        setFrame(nextFrame, display: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.isApplyingSavedPosition = false
+        }
+    }
+
+    private func resizeToFitContent() {
+        guard let hostingView else { return }
+
+        let fittingSize = hostingView.fittingSize
+        guard fittingSize.width > 0, fittingSize.height > 0 else { return }
+
+        setContentSize(fittingSize)
     }
     
     private func frame(on screen: NSScreen, verticalPositionRatio: Double) -> NSRect {
@@ -261,4 +299,5 @@ extension Notification.Name {
     static let launcherWindowDidBecomeKey = Notification.Name("launcherWindowDidBecomeKey")
     static let shouldFocusSearchField = Notification.Name("shouldFocusSearchField")
     static let launcherWindowWillHide = Notification.Name("launcherWindowWillHide")
+    static let launcherContentSizeDidChange = Notification.Name("launcherContentSizeDidChange")
 }


### PR DESCRIPTION
## Summary
- reset launcher search state on hide so stale results don't affect the next open
- resize/reposition the launcher panel when its SwiftUI content height changes
- select external video devices for Mirror before falling back to built-in/default cameras

## Review
- Smart review with Claude Opus: no blockers; addressed non-blocking duplicate resize notification note

## Testing
- `git diff --check`
- `xcodebuild -project trace.xcodeproj -scheme trace -configuration Debug -destination 'platform=macOS' build`