### PR TITLE
Fix settings window focus

### DIFF
--- a/trace.xcodeproj/project.pbxproj
+++ b/trace.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = H78GYE72WQ;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -319,7 +319,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.13.0;
+				MARKETING_VERSION = 1.14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techulus.trace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -337,7 +337,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = H78GYE72WQ;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -352,7 +352,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.13.0;
+				MARKETING_VERSION = 1.14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techulus.trace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/trace/Core/AppDelegate.swift
+++ b/trace/Core/AppDelegate.swift
@@ -206,7 +206,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem.separator())
         
         // Version and Build (disabled)
+        #if DEBUG
+        let versionText = "Version \(AppConstants.version) (\(AppConstants.build)) Debug"
+        #else
         let versionText = "Version \(AppConstants.version) (\(AppConstants.build))"
+        #endif
         let versionItem = NSMenuItem(title: versionText, action: nil, keyEquivalent: "")
         versionItem.isEnabled = false
         menu.addItem(versionItem)
@@ -506,19 +510,33 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Settings
     
     @objc func showSettings() {
-        if settingsWindow == nil {
-            settingsWindow = SettingsWindow()
+        launcherWindow?.hide(restoreFocus: false)
+        stopGlobalEventMonitoring()
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+
+            if self.settingsWindow == nil {
+                self.settingsWindow = SettingsWindow()
+            }
+            self.settingsWindow?.show()
+            self.logger.notice("✅ Settings window shown")
         }
-        settingsWindow?.show()
-        logger.notice("✅ Settings window shown")
     }
 
     @objc func showDictationSettings() {
-        if settingsWindow == nil {
-            settingsWindow = SettingsWindow(initialSection: .dictation)
+        launcherWindow?.hide(restoreFocus: false)
+        stopGlobalEventMonitoring()
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+
+            if self.settingsWindow == nil {
+                self.settingsWindow = SettingsWindow(initialSection: .dictation)
+            }
+            self.settingsWindow?.show(section: .dictation)
+            self.logger.notice("✅ Dictation settings shown")
         }
-        settingsWindow?.show(section: .dictation)
-        logger.notice("✅ Dictation settings shown")
     }
     
     

--- a/trace/Windows/SettingsWindow.swift
+++ b/trace/Windows/SettingsWindow.swift
@@ -71,13 +71,35 @@ class SettingsWindow: NSWindow {
     
     func show() {
         NSApp.activate(ignoringOtherApps: true)
+        NSRunningApplication.current.activate(options: [.activateAllWindows])
+
+        orderFrontRegardless()
         makeKeyAndOrderFront(nil)
+        makeMain()
         setIsVisible(true)
+
+        ensureFocus()
     }
 
     func show(section: TraceSettingsSection) {
         setupContent(initialSection: section)
         show()
+    }
+
+    private func ensureFocus() {
+        let delays: [TimeInterval] = [0.05, 0.15, 0.3]
+
+        for delay in delays {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                guard let self, self.isVisible else { return }
+
+                NSApp.activate(ignoringOtherApps: true)
+                NSRunningApplication.current.activate(options: [.activateAllWindows])
+                self.orderFrontRegardless()
+                self.makeKeyAndOrderFront(nil)
+                self.makeMain()
+            }
+        }
     }
     
     func hide() {


### PR DESCRIPTION
## Summary
- Ensure the settings window reliably becomes front/key/main when opened
- Hide the launcher without restoring previous-app focus before opening settings
- Show a Debug marker in the menu version line for DEBUG builds
- Bump version to 1.14.0 (33)

## Verification
- xcodebuild -project trace.xcodeproj -scheme trace -configuration Debug -destination 'platform=macOS' build