### PR TITLE
Add menu item search

### DIFF
--- a/trace/Core/Logging.swift
+++ b/trace/Core/Logging.swift
@@ -37,6 +37,7 @@ enum AppLogger {
     static let quickLinkHotkeyManager = logger(for: "QuickLinkHotkeyManager")
     static let permissionManager = logger(for: "PermissionManager")
     static let controlCenterManager = logger(for: "ControlCenterManager")
+    static let menuBarService = logger(for: "MenuBarService")
     static let processUsageMonitor = logger(for: "ProcessUsageMonitor")
     static let caffeinateManager = logger(for: "CaffeinateManager")
     static let mirrorManager = logger(for: "MirrorManager")

--- a/trace/Core/ServiceContainer.swift
+++ b/trace/Core/ServiceContainer.swift
@@ -23,6 +23,7 @@ class ServiceContainer: ObservableObject {
     private var _settingsManager: SettingsManager?
     private var _emojiManager: EmojiManager?
     private var _processUsageMonitor: ProcessUsageMonitor?
+    private var _menuBarService: MenuBarService?
     private var _caffeinateManager: CaffeinateManager?
     private var _mirrorManager: MirrorManager?
     private var _dictationCoordinator: DictationCoordinator?
@@ -147,6 +148,15 @@ class ServiceContainer: ObservableObject {
         return monitor
     }
 
+    var menuBarService: MenuBarService {
+        if let service = _menuBarService {
+            return service
+        }
+        let service = MenuBarService()
+        _menuBarService = service
+        return service
+    }
+
     @MainActor
     var dictationCoordinator: DictationCoordinator {
         if let coordinator = _dictationCoordinator {
@@ -192,6 +202,8 @@ class ServiceContainer: ObservableObject {
         _settingsManager = nil
         _emojiManager = nil
         _processUsageMonitor = nil
+        _menuBarService?.invalidateCache()
+        _menuBarService = nil
         _caffeinateManager?.stop()
         _caffeinateManager = nil
         Task { @MainActor in

--- a/trace/Models/SearchModels.swift
+++ b/trace/Models/SearchModels.swift
@@ -79,6 +79,7 @@ enum ResultCategory {
     case customFolder
     case appearance
     case systemSettings
+    case menuItems
     
     var displayName: String {
         switch self {
@@ -96,6 +97,8 @@ enum ResultCategory {
             return "Appearance"
         case .systemSettings:
             return "System Settings"
+        case .menuItems:
+            return "Menu Items"
         }
     }
 }

--- a/trace/Search/Providers/MenuItemProvider.swift
+++ b/trace/Search/Providers/MenuItemProvider.swift
@@ -1,0 +1,276 @@
+//
+//  MenuItemProvider.swift
+//  trace
+//
+//  Created by Codex on 8/7/2026.
+//
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+class MenuItemProvider: ResultProvider {
+    static let scopeToken = "menu:"
+    static let commandId = "com.trace.command.menu_items"
+    static let menuItemCommandPrefix = "com.trace.menu_item."
+    static let stateCommandPrefix = "com.trace.menu_state."
+    static let scopedResultLimit = AppConstants.Search.defaultLimit
+
+    private let setSearchText: (String) -> Void
+
+    init(setSearchText: @escaping (String) -> Void) {
+        self.setSearchText = setSearchText
+    }
+
+    func getResults(for query: String, context: SearchContext) async -> [(SearchResult, Double)] {
+        guard !Self.isScoped(query) else {
+            return []
+        }
+
+        let matchScore = matchesSearchTerms(query: query, terms: [
+            "search menu items",
+            "menu items",
+            "menu bar",
+            "app menu",
+            "application menu",
+            "menu"
+        ])
+        let usageScore = context.usageScores[Self.commandId] ?? 0.0
+
+        guard let score = calculateUnifiedScore(matchScore: matchScore, usageScore: usageScore) else {
+            return []
+        }
+
+        let action = InstantCommandAction(
+            id: Self.commandId,
+            displayName: "Search Menu Items",
+            iconName: "filemenu.and.selection",
+            operation: { [setSearchText] in
+                DispatchQueue.main.async {
+                    setSearchText(Self.scopeToken)
+                    NotificationCenter.default.post(name: .shouldFocusSearchField, object: nil)
+                }
+            }
+        )
+
+        let result = SearchResult(
+            title: "Search Menu Items",
+            subtitle: "Search the previous app's menu bar",
+            icon: .system("filemenu.and.selection"),
+            type: .command,
+            category: .menuItems,
+            shortcut: nil,
+            lastUsed: nil,
+            commandId: Self.commandId,
+            accessory: nil,
+            commandAction: action
+        )
+
+        return [(result, score)]
+    }
+
+    func scopedResults(filter: String, context: SearchContext) async -> [SearchResult] {
+        guard AXIsProcessTrusted() else {
+            return [permissionRequiredResult(context: context)]
+        }
+
+        guard let app = context.services.permissionManager.currentTargetApplication else {
+            return [emptyStateResult(
+                title: "No Target Application",
+                subtitle: "Focus another app, then open Trace again",
+                commandId: "\(Self.stateCommandPrefix)no_target"
+            )]
+        }
+
+        let items: [MenuItem]
+        do {
+            items = try context.services.menuBarService.menuItems(for: app)
+        } catch MenuBarServiceError.permissionDenied {
+            return [permissionRequiredResult(context: context)]
+        } catch {
+            return [emptyStateResult(
+                title: "No Menu Items Available",
+                subtitle: "\(app.localizedName ?? "This app") does not expose a readable menu bar",
+                commandId: "\(Self.stateCommandPrefix)no_menu"
+            )]
+        }
+
+        guard !items.isEmpty else {
+            return [emptyStateResult(
+                title: "No Menu Items Available",
+                subtitle: "\(app.localizedName ?? "This app") does not expose enabled menu items",
+                commandId: "\(Self.stateCommandPrefix)empty"
+            )]
+        }
+
+        let trimmedFilter = filter.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let rankedItems: [(MenuItem, Double)]
+
+        if trimmedFilter.isEmpty {
+            rankedItems = items.map { ($0, 1.0) }
+        } else {
+            rankedItems = items.compactMap { item in
+                let fullPath = item.pathTitles.joined(separator: " ").lowercased()
+                let titleScore = FuzzyMatcher.match(query: trimmedFilter, text: item.title.lowercased())
+                let pathScore = FuzzyMatcher.match(query: trimmedFilter, text: fullPath)
+                let score = max(titleScore, pathScore)
+                return score > 0.3 ? (item, score) : nil
+            }
+            .sorted { $0.1 > $1.1 }
+        }
+
+        guard !rankedItems.isEmpty else {
+            return [emptyStateResult(
+                title: "No Matching Menu Items",
+                subtitle: "Try a different menu item name",
+                commandId: "\(Self.stateCommandPrefix)no_matches"
+            )]
+        }
+
+        return rankedItems.prefix(Self.scopedResultLimit).map { item, _ in
+            menuItemResult(item, app: app, context: context)
+        }
+    }
+
+    static func isScoped(_ query: String) -> Bool {
+        query.lowercased().hasPrefix(scopeToken)
+    }
+
+    static func scopedFilter(from query: String) -> String {
+        guard isScoped(query) else { return query }
+        return String(query.dropFirst(scopeToken.count))
+    }
+
+    static func shouldSkipUsageTracking(commandId: String) -> Bool {
+        commandId.hasPrefix(menuItemCommandPrefix) || commandId.hasPrefix(stateCommandPrefix)
+    }
+
+    static func isStateCommand(commandId: String?) -> Bool {
+        commandId?.hasPrefix(stateCommandPrefix) == true
+    }
+
+    static func isMenuItemCommand(commandId: String?) -> Bool {
+        commandId?.hasPrefix(menuItemCommandPrefix) == true
+    }
+
+    private func menuItemResult(
+        _ item: MenuItem,
+        app: NSRunningApplication,
+        context: SearchContext
+    ) -> SearchResult {
+        let appID = app.bundleIdentifier ?? "unknown_app"
+        let commandId = "\(Self.menuItemCommandPrefix)\(sanitizeIdentifierComponent(appID)).\(item.id)"
+        let action = MenuItemCommandAction(
+            id: commandId,
+            displayName: item.title,
+            iconName: "filemenu.and.selection",
+            keyboardShortcut: item.shortcut?.displayString,
+            description: item.pathTitles.joined(separator: " > "),
+            item: item,
+            app: app,
+            menuBarService: context.services.menuBarService
+        )
+
+        return SearchResult(
+            title: item.title,
+            subtitle: subtitle(for: item, app: app),
+            icon: .system("filemenu.and.selection"),
+            type: .command,
+            category: .menuItems,
+            shortcut: item.shortcut,
+            lastUsed: nil,
+            commandId: commandId,
+            accessory: nil,
+            commandAction: action
+        )
+    }
+
+    private func subtitle(for item: MenuItem, app: NSRunningApplication) -> String {
+        let appName = app.localizedName ?? "Application"
+        guard !item.menuPath.isEmpty else {
+            return appName
+        }
+        return "\(appName) • \(item.menuPath)"
+    }
+
+    private func permissionRequiredResult(context: SearchContext) -> SearchResult {
+        let action = InstantCommandAction(
+            id: "\(Self.stateCommandPrefix)grant_accessibility",
+            displayName: "Grant Accessibility Access",
+            iconName: "hand.raised",
+            operation: {
+                context.services.permissionManager.requestWindowManagementPermissions()
+            }
+        )
+
+        return SearchResult(
+            title: "Grant Accessibility Access",
+            subtitle: "Trace needs Accessibility permission to read menu items",
+            icon: .system("hand.raised"),
+            type: .command,
+            category: .menuItems,
+            shortcut: nil,
+            lastUsed: nil,
+            commandId: "\(Self.stateCommandPrefix)grant_accessibility",
+            accessory: .status("Required", .orange),
+            commandAction: action
+        )
+    }
+
+    private func emptyStateResult(title: String, subtitle: String, commandId: String) -> SearchResult {
+        let action = InstantCommandAction(
+            id: commandId,
+            displayName: title,
+            iconName: "exclamationmark.circle",
+            operation: {}
+        )
+
+        return SearchResult(
+            title: title,
+            subtitle: subtitle,
+            icon: .system("exclamationmark.circle"),
+            type: .command,
+            category: .menuItems,
+            shortcut: nil,
+            lastUsed: nil,
+            commandId: commandId,
+            accessory: .status("Unavailable", .secondary),
+            commandAction: action
+        )
+    }
+
+    private func sanitizeIdentifierComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-"))
+        return value
+            .lowercased()
+            .unicodeScalars
+            .map { allowed.contains($0) ? Character($0) : "_" }
+            .reduce(into: "") { $0.append($1) }
+            .replacingOccurrences(of: "_+", with: "_", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+    }
+}
+
+struct MenuItemCommandAction: DisplayableCommandAction {
+    let id: String
+    let displayName: String
+    let iconName: String?
+    let keyboardShortcut: String?
+    let description: String?
+    let item: MenuItem
+    let app: NSRunningApplication
+    let menuBarService: MenuBarService
+    let showsLoadingState = false
+
+    func execute() async -> ActionResult {
+        let success = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: menuBarService.press(item, in: app))
+            }
+        }
+        if success {
+            return .success(message: nil, data: nil)
+        }
+        return .failure(error: "Could not press \(item.title)")
+    }
+}

--- a/trace/Services/MenuBarService.swift
+++ b/trace/Services/MenuBarService.swift
@@ -1,0 +1,369 @@
+//
+//  MenuBarService.swift
+//  trace
+//
+//  Created by Codex on 8/7/2026.
+//
+
+import AppKit
+import ApplicationServices
+import Foundation
+import os.log
+
+struct MenuItem {
+    let id: String
+    let pathTitles: [String]
+    let title: String
+    let menuPath: String
+    let shortcut: KeyboardShortcut?
+    let enabled: Bool
+    let element: AXUIElement
+}
+
+enum MenuBarServiceError: Error {
+    case permissionDenied
+    case menuBarUnavailable
+}
+
+class MenuBarService {
+    private struct CacheEntry {
+        let createdAt: CFAbsoluteTime
+        let items: [MenuItem]
+    }
+
+    private let logger = AppLogger.menuBarService
+    private let cacheLock = NSLock()
+    private var cache: [pid_t: CacheEntry] = [:]
+
+    private let cacheTTL: CFTimeInterval = 2.0
+    private let maxDepth = 6
+    private let maxItems = 500
+    private let menuAttribute = "AXMenu"
+    private let menuBarRole = "AXMenuBar"
+    private let menuBarItemRole = "AXMenuBarItem"
+    private let menuRole = "AXMenu"
+    private let menuItemRole = "AXMenuItem"
+
+    func menuItems(for app: NSRunningApplication) throws -> [MenuItem] {
+        guard AXIsProcessTrusted() else {
+            throw MenuBarServiceError.permissionDenied
+        }
+
+        let pid = app.processIdentifier
+        let now = CFAbsoluteTimeGetCurrent()
+
+        cacheLock.lock()
+        if let cached = cache[pid], now - cached.createdAt < cacheTTL {
+            cacheLock.unlock()
+            return cached.items
+        }
+        cacheLock.unlock()
+
+        let appElement = AXUIElementCreateApplication(pid)
+        guard let menuBar = elementAttribute(appElement, kAXMenuBarAttribute) else {
+            throw MenuBarServiceError.menuBarUnavailable
+        }
+
+        var collectedItems: [MenuItem] = []
+        var collectedCount = 0
+
+        collectItems(
+            from: menuBar,
+            path: [],
+            depth: 0,
+            count: &collectedCount,
+            output: &collectedItems
+        )
+
+        cacheLock.lock()
+        cache = cache.filter { $0.key == pid }
+        cache[pid] = CacheEntry(createdAt: now, items: collectedItems)
+        cacheLock.unlock()
+
+        logger.debug(
+            "Enumerated \(collectedItems.count) menu items for \(app.localizedName ?? app.bundleIdentifier ?? "Unknown", privacy: .public)"
+        )
+        return collectedItems
+    }
+
+    func press(_ item: MenuItem, in app: NSRunningApplication) -> Bool {
+        activate(app)
+        waitForActivation(of: app)
+
+        let result = AXUIElementPerformAction(item.element, kAXPressAction as CFString)
+        if result != .success {
+            logger.warning("Menu item press failed result=\(result.rawValue) item=\(item.title, privacy: .public)")
+        }
+
+        return result == .success
+    }
+
+    private func activate(_ app: NSRunningApplication) {
+        if Thread.isMainThread {
+            app.activate()
+        } else {
+            DispatchQueue.main.sync {
+                app.activate()
+            }
+        }
+    }
+
+    private func waitForActivation(of app: NSRunningApplication) {
+        let deadline = Date().addingTimeInterval(0.25)
+        while !app.isActive && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+    }
+
+    func invalidateCache(for app: NSRunningApplication? = nil) {
+        cacheLock.lock()
+        if let app {
+            cache.removeValue(forKey: app.processIdentifier)
+        } else {
+            cache.removeAll()
+        }
+        cacheLock.unlock()
+    }
+
+    private func collectItems(
+        from element: AXUIElement,
+        path: [String],
+        depth: Int,
+        count: inout Int,
+        output: inout [MenuItem]
+    ) {
+        guard depth <= maxDepth, count < maxItems else { return }
+
+        let role = role(of: element)
+        let title = title(of: element)
+
+        switch role {
+        case menuBarRole, menuRole:
+            for child in children(of: element) where count < maxItems {
+                collectItems(
+                    from: child,
+                    path: path,
+                    depth: depth + 1,
+                    count: &count,
+                    output: &output
+                )
+            }
+
+        case menuBarItemRole:
+            let nextPath = title.isEmpty ? path : path + [title]
+            let menus = menuContainers(of: element)
+            if menus.isEmpty {
+                for child in children(of: element) where count < maxItems {
+                    collectItems(
+                        from: child,
+                        path: nextPath,
+                        depth: depth + 1,
+                        count: &count,
+                        output: &output
+                    )
+                }
+            } else {
+                for menu in menus where count < maxItems {
+                    collectItems(
+                        from: menu,
+                        path: nextPath,
+                        depth: depth + 1,
+                        count: &count,
+                        output: &output
+                    )
+                }
+            }
+
+        case menuItemRole:
+            guard !title.isEmpty else { return }
+            let nextPath = path + [title]
+            let menus = menuContainers(of: element)
+
+            if !menus.isEmpty {
+                for menu in menus where count < maxItems {
+                    collectItems(
+                        from: menu,
+                        path: nextPath,
+                        depth: depth + 1,
+                        count: &count,
+                        output: &output
+                    )
+                }
+                return
+            }
+
+            let enabled = boolAttribute(element, kAXEnabledAttribute, defaultValue: true)
+            guard enabled else { return }
+
+            let item = MenuItem(
+                id: makeItemID(pathTitles: nextPath),
+                pathTitles: nextPath,
+                title: title,
+                menuPath: path.joined(separator: " > "),
+                shortcut: keyboardShortcut(for: element),
+                enabled: enabled,
+                element: element
+            )
+
+            output.append(item)
+            count += 1
+
+        default:
+            for child in children(of: element) where count < maxItems {
+                collectItems(
+                    from: child,
+                    path: path,
+                    depth: depth + 1,
+                    count: &count,
+                    output: &output
+                )
+            }
+        }
+    }
+
+    private func menuContainers(of element: AXUIElement) -> [AXUIElement] {
+        var menus: [AXUIElement] = []
+
+        if let menu = elementAttribute(element, menuAttribute) {
+            menus.append(menu)
+        }
+
+        for child in children(of: element) where role(of: child) == menuRole {
+            if !menus.contains(where: { CFEqual($0, child) }) {
+                menus.append(child)
+            }
+        }
+
+        return menus
+    }
+
+    private func makeItemID(pathTitles: [String]) -> String {
+        pathTitles
+            .map { sanitizeIdentifierComponent($0) }
+            .filter { !$0.isEmpty }
+            .joined(separator: ".")
+    }
+
+    private func sanitizeIdentifierComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-"))
+        return value
+            .lowercased()
+            .unicodeScalars
+            .map { allowed.contains($0) ? Character($0) : "_" }
+            .reduce(into: "") { $0.append($1) }
+            .replacingOccurrences(of: "_+", with: "_", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+    }
+
+    private func keyboardShortcut(for element: AXUIElement) -> KeyboardShortcut? {
+        let key = stringAttribute(element, kAXMenuItemCmdCharAttribute)
+            ?? keyName(forVirtualKey: intAttribute(element, kAXMenuItemCmdVirtualKeyAttribute))
+
+        guard let key, !key.isEmpty else {
+            return nil
+        }
+
+        return KeyboardShortcut(
+            key: key.uppercased(),
+            modifiers: modifiers(from: intAttribute(element, kAXMenuItemCmdModifiersAttribute))
+        )
+    }
+
+    private func modifiers(from mask: Int?) -> [String] {
+        guard let mask else {
+            return ["⌘"]
+        }
+
+        var modifiers: [String] = []
+        if mask & 4 != 0 { modifiers.append("⌃") }
+        if mask & 2 != 0 { modifiers.append("⌥") }
+        if mask & 1 != 0 { modifiers.append("⇧") }
+        if mask & 8 == 0 { modifiers.append("⌘") }
+
+        return modifiers.isEmpty ? ["⌘"] : modifiers
+    }
+
+    private func keyName(forVirtualKey value: Int?) -> String? {
+        guard let value else { return nil }
+
+        switch value {
+        case 36: return "↩"
+        case 48: return "⇥"
+        case 49: return "Space"
+        case 51: return "⌫"
+        case 53: return "⎋"
+        case 115: return "Home"
+        case 116: return "Page Up"
+        case 117: return "⌦"
+        case 119: return "End"
+        case 121: return "Page Down"
+        case 123: return "←"
+        case 124: return "→"
+        case 125: return "↓"
+        case 126: return "↑"
+        default: return nil
+        }
+    }
+
+    private func title(of element: AXUIElement, fallback: String = "") -> String {
+        (stringAttribute(element, kAXTitleAttribute) ?? fallback)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func role(of element: AXUIElement) -> String {
+        stringAttribute(element, kAXRoleAttribute) ?? ""
+    }
+
+    private func children(of element: AXUIElement) -> [AXUIElement] {
+        arrayAttribute(element, kAXChildrenAttribute)
+    }
+
+    private func stringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+            return nil
+        }
+        return value as? String
+    }
+
+    private func intAttribute(_ element: AXUIElement, _ attribute: String) -> Int? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+            return nil
+        }
+        if let intValue = value as? Int {
+            return intValue
+        }
+        return (value as? NSNumber)?.intValue
+    }
+
+    private func boolAttribute(_ element: AXUIElement, _ attribute: String, defaultValue: Bool) -> Bool {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+            return defaultValue
+        }
+        if let boolValue = value as? Bool {
+            return boolValue
+        }
+        return (value as? NSNumber)?.boolValue ?? defaultValue
+    }
+
+    private func elementAttribute(_ element: AXUIElement, _ attribute: String) -> AXUIElement? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+            return nil
+        }
+        guard let value, CFGetTypeID(value) == AXUIElementGetTypeID() else {
+            return nil
+        }
+        return (value as! AXUIElement)
+    }
+
+    private func arrayAttribute(_ element: AXUIElement, _ attribute: String) -> [AXUIElement] {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+            return []
+        }
+        return value as? [AXUIElement] ?? []
+    }
+}

--- a/trace/Services/PermissionManager.swift
+++ b/trace/Services/PermissionManager.swift
@@ -171,6 +171,10 @@ class PermissionManager: ObservableObject {
         logger.debug("No suitable application with windows found")
         return nil
     }
+
+    var currentTargetApplication: NSRunningApplication? {
+        findTargetApplication()
+    }
     
     /// Attempts to request accessibility permissions with proper user guidance
     func requestWindowManagementPermissions() {

--- a/trace/Views/LauncherSearchLogic.swift
+++ b/trace/Views/LauncherSearchLogic.swift
@@ -107,6 +107,20 @@ extension LauncherView {
     /// Calculate search results using provider system
     func calculateSearchResults(query: String) async -> [SearchResult] {
         let runningApps = services.appSearchManager.getRunningAppBundleIds()
+
+        if MenuItemProvider.isScoped(query) {
+            let context = SearchContext(
+                query: query,
+                services: services,
+                runningApps: runningApps,
+                eventPublisher: eventPublisher
+            )
+            return await createMenuItemProvider().scopedResults(
+                filter: MenuItemProvider.scopedFilter(from: query),
+                context: context
+            )
+        }
+
         let searchCoordinator = createSearchCoordinator()
         
         return await searchCoordinator.search(
@@ -121,6 +135,7 @@ extension LauncherView {
     private func createSearchCoordinator() -> SearchCoordinator {
         let providers: [ResultProvider] = [
             AppResultProvider(),
+            createMenuItemProvider(),
             SystemCommandProvider(
                 clearSearch: clearSearch,
                 onClose: onClose
@@ -136,6 +151,12 @@ extension LauncherView {
         ]
         
         return SearchCoordinator(providers: providers)
+    }
+
+    private func createMenuItemProvider() -> MenuItemProvider {
+        MenuItemProvider(setSearchText: { newValue in
+            searchText = newValue
+        })
     }
     
     
@@ -264,7 +285,9 @@ extension LauncherView {
         case .command:
             // Use the command's semantic identifier for tracking
             let commandId = result.commandId ?? getCommandIdentifier(for: result.title)
-            services.usageTracker.recordUsage(for: commandId, type: UsageType.command)
+            if !MenuItemProvider.shouldSkipUsageTracking(commandId: commandId) {
+                services.usageTracker.recordUsage(for: commandId, type: UsageType.command)
+            }
         case .suggestion:
             let commandId = result.commandId ?? "com.trace.search.unknown"
             services.usageTracker.recordUsage(for: commandId, type: UsageType.webSearch)
@@ -318,6 +341,20 @@ extension LauncherView {
                 } else if result.commandId == "com.trace.command.settings" {
                     // Don't close launcher
                     clearSearch()
+                } else if result.commandId == MenuItemProvider.commandId {
+                    selectedIndex = 0
+                    selectedActionIndex = 0
+                } else if MenuItemProvider.isStateCommand(commandId: result.commandId) {
+                    selectedIndex = 0
+                    selectedActionIndex = 0
+                } else if MenuItemProvider.isMenuItemCommand(commandId: result.commandId) {
+                    if success {
+                        clearSearch()
+                        onClose()
+                    } else {
+                        selectedIndex = 0
+                        selectedActionIndex = 0
+                    }
                 } else {
                     // For other commands, close launcher
                     clearSearch()


### PR DESCRIPTION
## Summary

- Adds `menu:` scoped search for the target app's menu bar items.
- Enumerates menu items through Accessibility with role-based traversal, shortcut labels, enabled state, caching, and action execution.
- Wires menu search into launcher routing with state rows for permission, target-app, empty-menu, and no-match cases.

## Review Notes

- Smart Review findings were addressed and rechecked before updating this PR:
  - menu actions now activate/poll off the main actor before pressing;
  - the scoped token now uses `menu:` so normal literal searches like `menu bar` are not hijacked;
  - scoped results are capped;
  - state rows stay non-destructive and do not close the launcher;
  - menu item/state commands are excluded from usage tracking;
  - shortcut modifier decoding now avoids the misleading high-mask branch and renders in canonical modifier order.
- The second Smart Review found no blocking correctness or race issues remaining.

## Validation

- `xcodebuild -project trace.xcodeproj -scheme trace -configuration Debug build`

## Caveat

- AX inspection from shell could not verify live app menus because the shell process is not Accessibility-trusted. The implementation should be manually smoke-tested through the signed Trace app against apps such as Xcode and Dia.
