### PR TITLE
Add option to start Caffeinate when Trace launches

### DIFF
--- a/trace/Core/AppDelegate.swift
+++ b/trace/Core/AppDelegate.swift
@@ -63,6 +63,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setupMenuBar()
         setupSettingsObservation()
         setupCaffeinateObservation()
+        setupCaffeinateSleepObservation()
         startCaffeinateIfNeededOnLaunch()
         
         // Initialize window hotkey manager to register saved hotkeys
@@ -112,6 +113,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         settingsWindow?.hide()
         settingsWindow = nil
         NotificationCenter.default.removeObserver(self)
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
         settingsCancellable?.cancel()
         logger.debug("AppDelegate deinitialized")
     }
@@ -310,6 +312,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             name: CaffeinateManager.statusDidChangeNotification,
             object: nil
         )
+    }
+
+    private func setupCaffeinateSleepObservation() {
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(workspaceWillSleep(_:)),
+            name: NSWorkspace.willSleepNotification,
+            object: nil
+        )
+    }
+
+    @objc private func workspaceWillSleep(_ notification: Notification) {
+        guard settingsManager.settings.stopCaffeinateOnSleep,
+              caffeinateManager.isActive else { return }
+
+        logger.notice("Stopping caffeinate because the Mac is going to sleep")
+        caffeinateManager.stop()
     }
 
     private func startCaffeinateIfNeededOnLaunch() {

--- a/trace/Core/AppDelegate.swift
+++ b/trace/Core/AppDelegate.swift
@@ -63,6 +63,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setupMenuBar()
         setupSettingsObservation()
         setupCaffeinateObservation()
+        startCaffeinateIfNeededOnLaunch()
         
         // Initialize window hotkey manager to register saved hotkeys
         _ = WindowHotkeyManager.shared
@@ -309,6 +310,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             name: CaffeinateManager.statusDidChangeNotification,
             object: nil
         )
+    }
+
+    private func startCaffeinateIfNeededOnLaunch() {
+        guard settingsManager.settings.startCaffeinateOnLaunch else { return }
+
+        if caffeinateManager.start() {
+            logger.notice("Started caffeinate automatically on launch")
+        } else {
+            logger.error("Failed to start caffeinate on launch")
+        }
     }
 
     private func updateStatusItemAppearance() {

--- a/trace/Services/SettingsManager.swift
+++ b/trace/Services/SettingsManager.swift
@@ -26,6 +26,7 @@ struct TraceSettings: Codable {
     var caffeinateFlags: String = CaffeinateManager.defaultFlags
     /// Empty string means camera selection follows the macOS system preference.
     var mirrorCameraDeviceID: String = ""
+    var startCaffeinateOnLaunch: Bool = false
     var dictationEnabled: Bool = false
     var dictationHotkey: String = ""
     var dictationHotkeyKeyCode: Int = 0
@@ -72,6 +73,7 @@ struct TraceSettings: Codable {
         )
         caffeinateFlags = try container.decodeIfPresent(String.self, forKey: .caffeinateFlags) ?? CaffeinateManager.defaultFlags
         mirrorCameraDeviceID = try container.decodeIfPresent(String.self, forKey: .mirrorCameraDeviceID) ?? ""
+        startCaffeinateOnLaunch = try container.decodeIfPresent(Bool.self, forKey: .startCaffeinateOnLaunch) ?? false
         dictationEnabled = try container.decodeIfPresent(Bool.self, forKey: .dictationEnabled) ?? false
         dictationHotkey = try container.decodeIfPresent(String.self, forKey: .dictationHotkey) ?? ""
         dictationHotkeyKeyCode = try container.decodeIfPresent(Int.self, forKey: .dictationHotkeyKeyCode) ?? 0
@@ -444,6 +446,13 @@ class SettingsManager: ObservableObject {
         guard settings.mirrorCameraDeviceID != deviceID else { return }
 
         settings.mirrorCameraDeviceID = deviceID
+        saveSettings()
+    }
+
+    func updateStartCaffeinateOnLaunch(_ enabled: Bool) {
+        guard settings.startCaffeinateOnLaunch != enabled else { return }
+
+        settings.startCaffeinateOnLaunch = enabled
         saveSettings()
     }
 

--- a/trace/Services/SettingsManager.swift
+++ b/trace/Services/SettingsManager.swift
@@ -27,6 +27,7 @@ struct TraceSettings: Codable {
     /// Empty string means camera selection follows the macOS system preference.
     var mirrorCameraDeviceID: String = ""
     var startCaffeinateOnLaunch: Bool = false
+    var stopCaffeinateOnSleep: Bool = false
     var dictationEnabled: Bool = false
     var dictationHotkey: String = ""
     var dictationHotkeyKeyCode: Int = 0
@@ -74,6 +75,7 @@ struct TraceSettings: Codable {
         caffeinateFlags = try container.decodeIfPresent(String.self, forKey: .caffeinateFlags) ?? CaffeinateManager.defaultFlags
         mirrorCameraDeviceID = try container.decodeIfPresent(String.self, forKey: .mirrorCameraDeviceID) ?? ""
         startCaffeinateOnLaunch = try container.decodeIfPresent(Bool.self, forKey: .startCaffeinateOnLaunch) ?? false
+        stopCaffeinateOnSleep = try container.decodeIfPresent(Bool.self, forKey: .stopCaffeinateOnSleep) ?? false
         dictationEnabled = try container.decodeIfPresent(Bool.self, forKey: .dictationEnabled) ?? false
         dictationHotkey = try container.decodeIfPresent(String.self, forKey: .dictationHotkey) ?? ""
         dictationHotkeyKeyCode = try container.decodeIfPresent(Int.self, forKey: .dictationHotkeyKeyCode) ?? 0
@@ -456,6 +458,13 @@ class SettingsManager: ObservableObject {
         saveSettings()
     }
 
+    func updateStopCaffeinateOnSleep(_ enabled: Bool) {
+        guard settings.stopCaffeinateOnSleep != enabled else { return }
+
+        settings.stopCaffeinateOnSleep = enabled
+        saveSettings()
+    }
+
     // MARK: - Dictation
 
     func updateDictationEnabled(_ enabled: Bool) {
@@ -624,6 +633,14 @@ class SettingsManager: ObservableObject {
 
             if settings.mirrorCameraDeviceID.isEmpty {
                 settings.mirrorCameraDeviceID = importedSettings.mirrorCameraDeviceID
+            }
+
+            if !settings.startCaffeinateOnLaunch {
+                settings.startCaffeinateOnLaunch = importedSettings.startCaffeinateOnLaunch
+            }
+
+            if !settings.stopCaffeinateOnSleep {
+                settings.stopCaffeinateOnSleep = importedSettings.stopCaffeinateOnSleep
             }
 
             // Main hotkey - only update if current is default

--- a/trace/Views/Settings/AboutSettingsView.swift
+++ b/trace/Views/Settings/AboutSettingsView.swift
@@ -40,20 +40,20 @@ struct AboutSettingsView: View {
                     }
 
 
-                    // Developer Info and Links
+                    // Open-source community and links
                     VStack(spacing: 8) {
-                        Text("Created by Arjun Komath")
+                        Text("Built by the Trace open-source community")
                             .font(.system(size: 12))
                             .foregroundColor(.secondary)
 
                         HStack(spacing: 20) {
-                            if let githubURL = URL(string: "https://github.com/arjunkomath") {
-                                Link("GitHub", destination: githubURL)
+                            if let contributorsURL = URL(string: "https://github.com/arjunkomath/trace/graphs/contributors?all=1") {
+                                Link("Contributors", destination: contributorsURL)
                                     .font(.system(size: 12))
                             }
 
-                            if let twitterURL = URL(string: "https://twitter.com/arjunz") {
-                                Link("Twitter / X", destination: twitterURL)
+                            if let repositoryURL = URL(string: "https://github.com/arjunkomath/trace") {
+                                Link("Source Code", destination: repositoryURL)
                                     .font(.system(size: 12))
                             }
                         }

--- a/trace/Views/Settings/CaffeinateSettingsView.swift
+++ b/trace/Views/Settings/CaffeinateSettingsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CaffeinateSettingsView: View {
     @State private var caffeinateActive = false
     @State private var startCaffeinateOnLaunch = false
+    @State private var stopCaffeinateOnSleep = false
     @State private var keepDisplayAwake = true
     @State private var preventIdleSleep = true
     @State private var preventDiskSleep = true
@@ -23,7 +24,7 @@ struct CaffeinateSettingsView: View {
 
     var body: some View {
         NativeSettingsPane {
-            NativeSettingsSection("Caffeinate") {
+            NativeSettingsSection("Keep Awake") {
                 NativeSettingsRow(
                     title: "Command",
                     subtitle: "Built automatically from your choices"
@@ -60,8 +61,24 @@ struct CaffeinateSettingsView: View {
                     Toggle("", isOn: $startCaffeinateOnLaunch)
                         .toggleStyle(.checkbox)
                         .labelsHidden()
+                        .accessibilityLabel(Text("Start on Launch"))
                         .onChange(of: startCaffeinateOnLaunch) { _, enabled in
                             settingsManager.updateStartCaffeinateOnLaunch(enabled)
+                        }
+                }
+
+                NativeSettingsDivider()
+
+                NativeSettingsRow(
+                    title: "Stop When Mac Sleeps",
+                    subtitle: "Turns off Caffeinate when macOS sleeps; it stays off after wake"
+                ) {
+                    Toggle("", isOn: $stopCaffeinateOnSleep)
+                        .toggleStyle(.checkbox)
+                        .labelsHidden()
+                        .accessibilityLabel(Text("Stop When Mac Sleeps"))
+                        .onChange(of: stopCaffeinateOnSleep) { _, enabled in
+                            settingsManager.updateStopCaffeinateOnSleep(enabled)
                         }
                 }
 
@@ -193,6 +210,7 @@ struct CaffeinateSettingsView: View {
         .onAppear {
             caffeinateActive = ServiceContainer.shared.caffeinateManager.isActive
             startCaffeinateOnLaunch = settingsManager.settings.startCaffeinateOnLaunch
+            stopCaffeinateOnSleep = settingsManager.settings.stopCaffeinateOnSleep
             loadCaffeinateOptions()
         }
         .onReceive(NotificationCenter.default.publisher(for: CaffeinateManager.statusDidChangeNotification)) { _ in

--- a/trace/Views/Settings/CaffeinateSettingsView.swift
+++ b/trace/Views/Settings/CaffeinateSettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CaffeinateSettingsView: View {
     @State private var caffeinateActive = false
+    @State private var startCaffeinateOnLaunch = false
     @State private var keepDisplayAwake = true
     @State private var preventIdleSleep = true
     @State private var preventDiskSleep = true
@@ -48,6 +49,20 @@ struct CaffeinateSettingsView: View {
                         .help("Reset Caffeinate options")
                         .disabled(caffeinateFlagsPreview == CaffeinateManager.defaultFlags)
                     }
+                }
+
+                NativeSettingsDivider()
+
+                NativeSettingsRow(
+                    title: "Start on Launch",
+                    subtitle: "Automatically start Caffeinate when Trace opens"
+                ) {
+                    Toggle("", isOn: $startCaffeinateOnLaunch)
+                        .toggleStyle(.checkbox)
+                        .labelsHidden()
+                        .onChange(of: startCaffeinateOnLaunch) { _, enabled in
+                            settingsManager.updateStartCaffeinateOnLaunch(enabled)
+                        }
                 }
 
                 NativeSettingsDivider()
@@ -177,6 +192,7 @@ struct CaffeinateSettingsView: View {
         }
         .onAppear {
             caffeinateActive = ServiceContainer.shared.caffeinateManager.isActive
+            startCaffeinateOnLaunch = settingsManager.settings.startCaffeinateOnLaunch
             loadCaffeinateOptions()
         }
         .onReceive(NotificationCenter.default.publisher(for: CaffeinateManager.statusDidChangeNotification)) { _ in

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -27,7 +27,7 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         case .dictation:
             return "Dictation"
         case .caffeinate:
-            return "Caffeinate"
+            return "Keep Awake"
         case .windowHotkeys:
             return "Window Management"
         case .appHotkeys:
@@ -46,7 +46,7 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         case .dictation:
             return "Dictation"
         case .caffeinate:
-            return "Caffeinate"
+            return "Keep Awake"
         case .windowHotkeys:
             return "Windows"
         case .appHotkeys:


### PR DESCRIPTION
Add a Start on Launch toggle in Caffeinate settings so Trace can automatically run caffeinate with the user's configured flags on app start.