### PR TITLE
Add Default Mirror camera selection(with Continuity Camera discovery)

### DIFF
--- a/trace/Info.plist
+++ b/trace/Info.plist
@@ -46,6 +46,8 @@
     <string>Trace needs access to your calendar to help you search for and quickly access your events.</string>
     <key>NSCameraUsageDescription</key>
     <string>Trace uses the camera only to show a temporary local mirror preview. Trace does not record, save, or send camera video.</string>
+    <key>NSCameraUseContinuityCameraDeviceType</key>
+    <true/>
     <key>NSMicrophoneUsageDescription</key>
     <string>Trace needs microphone access to transcribe your speech locally for dictation.</string>
     <key>NSSpeechRecognitionUsageDescription</key>

--- a/trace/Services/MirrorManager.swift
+++ b/trace/Services/MirrorManager.swift
@@ -20,6 +20,7 @@ final class MirrorManager {
     private var retiringMirrorWindow: MirrorWindow?
     private var autoHideWorkItem: DispatchWorkItem?
     private var runtimeErrorObserver: NSObjectProtocol?
+    private var systemPreferredCameraObserver: SystemPreferredCameraObserver?
 
     var isVisible: Bool {
         mirrorWindow?.isVisible == true
@@ -54,6 +55,7 @@ final class MirrorManager {
     func hide(completion: (() -> Void)? = nil) {
         stopAutoHideTimer()
         stopRuntimeErrorObservation()
+        stopSystemPreferredCameraObservation()
 
         guard let mirrorWindow else {
             if retiringMirrorWindow == nil {
@@ -97,6 +99,8 @@ final class MirrorManager {
             scheduleAutoHide()
             return
         }
+
+        updateSystemPreferredCameraObservation()
 
         do {
             let session = try makePreviewSession()
@@ -219,6 +223,39 @@ final class MirrorManager {
         hide { [weak self] in
             self?.show()
         }
+    }
+
+    private func updateSystemPreferredCameraObservation() {
+        guard SettingsManager.shared.settings.mirrorCameraDeviceID.isEmpty else {
+            stopSystemPreferredCameraObservation()
+            return
+        }
+        guard systemPreferredCameraObserver == nil else { return }
+
+        systemPreferredCameraObserver = SystemPreferredCameraObserver { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.systemPreferredCameraDidChange()
+            }
+        }
+    }
+
+    private func stopSystemPreferredCameraObservation() {
+        systemPreferredCameraObserver = nil
+    }
+
+    private func systemPreferredCameraDidChange() {
+        guard SettingsManager.shared.settings.mirrorCameraDeviceID.isEmpty,
+              isVisible,
+              let preferredCamera = AVCaptureDevice.systemPreferredCamera else {
+            return
+        }
+
+        let activeCamera = session?.inputs
+            .compactMap { ($0 as? AVCaptureDeviceInput)?.device }
+            .first
+        guard activeCamera?.uniqueID != preferredCamera.uniqueID else { return }
+
+        applyCameraSelectionChange()
     }
 
     private func preferredCamera() -> AVCaptureDevice? {
@@ -375,6 +412,46 @@ final class MirrorManager {
             NotificationCenter.default.removeObserver(runtimeErrorObserver)
             self.runtimeErrorObserver = nil
         }
+    }
+}
+
+private final class SystemPreferredCameraObserver: NSObject {
+    private static let keyPath = "systemPreferredCamera"
+
+    private let onChange: () -> Void
+
+    init(onChange: @escaping () -> Void) {
+        self.onChange = onChange
+        super.init()
+        AVCaptureDevice.addObserver(
+            self,
+            forKeyPath: Self.keyPath,
+            options: [.new],
+            context: nil
+        )
+    }
+
+    deinit {
+        AVCaptureDevice.removeObserver(self, forKeyPath: Self.keyPath)
+    }
+
+    override func observeValue(
+        forKeyPath keyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey: Any]?,
+        context: UnsafeMutableRawPointer?
+    ) {
+        guard keyPath == Self.keyPath else {
+            super.observeValue(
+                forKeyPath: keyPath,
+                of: object,
+                change: change,
+                context: context
+            )
+            return
+        }
+
+        onChange()
     }
 }
 

--- a/trace/Services/MirrorManager.swift
+++ b/trace/Services/MirrorManager.swift
@@ -141,18 +141,194 @@ final class MirrorManager {
         return session
     }
 
-    private func preferredCamera() -> AVCaptureDevice? {
-        let discoverySession = AVCaptureDevice.DiscoverySession(
-            deviceTypes: [.external, .builtInWideAngleCamera],
+    /// Retained discovery session so Continuity Camera / external devices stay observable.
+    /// Creating a throwaway session each call can miss Continuity devices that appear later.
+    private static let videoDiscoverySession: AVCaptureDevice.DiscoverySession = {
+        makeVideoDiscoverySession()
+    }()
+
+    private static func makeVideoDiscoverySession() -> AVCaptureDevice.DiscoverySession {
+        // Include every macOS video device type that can surface a camera.
+        // Continuity Camera requires NSCameraUseContinuityCameraDeviceType in Info.plist
+        // and the .continuityCamera type (macOS 14+).
+        var deviceTypes: [AVCaptureDevice.DeviceType] = [
+            .builtInWideAngleCamera,
+            .external
+        ]
+
+        if #available(macOS 13.0, *) {
+            deviceTypes.append(.deskViewCamera)
+        }
+        if #available(macOS 14.0, *) {
+            deviceTypes.append(.continuityCamera)
+        }
+
+        return AVCaptureDevice.DiscoverySession(
+            deviceTypes: deviceTypes,
             mediaType: .video,
             position: .unspecified
         )
+    }
 
-        if let externalCamera = discoverySession.devices.first(where: { $0.deviceType == .external }) {
-            return externalCamera
+    /// Cameras available for Mirror, sorted with built-in devices first.
+    /// Includes Continuity Camera (iPhone/iPad), Desk View, USB webcams, and built-in FaceTime.
+    static func availableCameras() -> [AVCaptureDevice] {
+        // Touch the retained session so it stays warm for connect/disconnect updates.
+        _ = videoDiscoverySession
+
+        var devicesByID: [String: AVCaptureDevice] = [:]
+
+        for device in videoDiscoverySession.devices {
+            devicesByID[device.uniqueID] = device
         }
 
-        return discoverySession.devices.first ?? AVCaptureDevice.default(for: .video)
+        // Also merge a fresh session in case the retained one lags after permission grant.
+        for device in makeVideoDiscoverySession().devices {
+            devicesByID[device.uniqueID] = device
+        }
+
+        // Prefer/system cameras can surface Continuity Camera even when discovery is incomplete.
+        if #available(macOS 14.0, *) {
+            if let systemPreferred = AVCaptureDevice.systemPreferredCamera {
+                devicesByID[systemPreferred.uniqueID] = systemPreferred
+            }
+            if let userPreferred = AVCaptureDevice.userPreferredCamera {
+                devicesByID[userPreferred.uniqueID] = userPreferred
+            }
+            if let continuity = AVCaptureDevice.default(
+                .continuityCamera,
+                for: .video,
+                position: .unspecified
+            ) {
+                devicesByID[continuity.uniqueID] = continuity
+            }
+        }
+
+        if #available(macOS 13.0, *) {
+            if let deskView = AVCaptureDevice.default(
+                .deskViewCamera,
+                for: .video,
+                position: .unspecified
+            ) {
+                devicesByID[deskView.uniqueID] = deskView
+            }
+        }
+
+        if let builtIn = AVCaptureDevice.default(
+            .builtInWideAngleCamera,
+            for: .video,
+            position: .unspecified
+        ) {
+            devicesByID[builtIn.uniqueID] = builtIn
+        }
+
+        if let external = AVCaptureDevice.default(
+            .external,
+            for: .video,
+            position: .unspecified
+        ) {
+            devicesByID[external.uniqueID] = external
+        }
+
+        if let defaultVideo = AVCaptureDevice.default(for: .video) {
+            devicesByID[defaultVideo.uniqueID] = defaultVideo
+        }
+
+        return devicesByID.values.sorted { lhs, rhs in
+            let lhsRank = cameraSortRank(for: lhs)
+            let rhsRank = cameraSortRank(for: rhs)
+            if lhsRank != rhsRank {
+                return lhsRank < rhsRank
+            }
+            return lhs.localizedName.localizedCaseInsensitiveCompare(rhs.localizedName) == .orderedAscending
+        }
+    }
+
+    /// Human-readable label for settings pickers.
+    static func displayName(for device: AVCaptureDevice) -> String {
+        let name = device.localizedName
+
+        if #available(macOS 14.0, *), device.isContinuityCamera || device.deviceType == .continuityCamera {
+            if name.localizedCaseInsensitiveContains("iphone")
+                || name.localizedCaseInsensitiveContains("ipad")
+                || name.localizedCaseInsensitiveContains("continuity") {
+                return name
+            }
+            return "\(name) (Continuity Camera)"
+        }
+
+        if #available(macOS 13.0, *), device.deviceType == .deskViewCamera {
+            if name.localizedCaseInsensitiveContains("desk") {
+                return name
+            }
+            return "\(name) (Desk View)"
+        }
+
+        if device.deviceType == .external {
+            return "\(name) (External)"
+        }
+
+        return name
+    }
+
+    private static func cameraSortRank(for device: AVCaptureDevice) -> Int {
+        if device.deviceType == .builtInWideAngleCamera {
+            return 0
+        }
+        if #available(macOS 13.0, *), device.deviceType == .deskViewCamera {
+            return 3
+        }
+        if #available(macOS 14.0, *) {
+            if device.isContinuityCamera || device.deviceType == .continuityCamera {
+                return 2
+            }
+        }
+        if device.deviceType == .external {
+            return 2
+        }
+        return 1
+    }
+
+    private static func isContinuityOrExternal(_ device: AVCaptureDevice) -> Bool {
+        if #available(macOS 14.0, *), device.isContinuityCamera || device.deviceType == .continuityCamera {
+            return true
+        }
+        if #available(macOS 13.0, *), device.deviceType == .deskViewCamera {
+            return true
+        }
+        return device.deviceType == .external
+    }
+
+    /// Restart Mirror if it's open so a newly chosen camera takes effect.
+    func applyCameraSelectionChange() {
+        guard isVisible else { return }
+
+        hide()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+            self?.show()
+        }
+    }
+
+    private func preferredCamera() -> AVCaptureDevice? {
+        let devices = Self.availableCameras()
+        let preferredID = SettingsManager.shared.settings.mirrorCameraDeviceID
+
+        // Explicit user selection takes priority when the device is still available.
+        if !preferredID.isEmpty,
+           let selected = devices.first(where: { $0.uniqueID == preferredID }) {
+            return selected
+        }
+
+        // Automatic: prefer built-in FaceTime camera over Continuity Camera / external.
+        if let builtIn = devices.first(where: { $0.deviceType == .builtInWideAngleCamera }) {
+            return builtIn
+        }
+
+        if let nonExternal = devices.first(where: { !Self.isContinuityOrExternal($0) }) {
+            return nonExternal
+        }
+
+        return devices.first ?? AVCaptureDevice.default(for: .video)
     }
 
     private func configureUserSelectedVideoEffects(for camera: AVCaptureDevice) {

--- a/trace/Services/MirrorManager.swift
+++ b/trace/Services/MirrorManager.swift
@@ -51,7 +51,7 @@ final class MirrorManager {
         }
     }
 
-    func hide() {
+    func hide(completion: (() -> Void)? = nil) {
         stopAutoHideTimer()
         stopRuntimeErrorObservation()
 
@@ -59,6 +59,7 @@ final class MirrorManager {
             if retiringMirrorWindow == nil {
                 stopSession(session)
             }
+            completion?()
             return
         }
 
@@ -73,6 +74,7 @@ final class MirrorManager {
             }
 
             self.stopSession(outgoingSession)
+            completion?()
         }
     }
 
@@ -143,98 +145,21 @@ final class MirrorManager {
 
     /// Retained discovery session so Continuity Camera / external devices stay observable.
     /// Creating a throwaway session each call can miss Continuity devices that appear later.
-    private static let videoDiscoverySession: AVCaptureDevice.DiscoverySession = {
-        makeVideoDiscoverySession()
-    }()
-
-    private static func makeVideoDiscoverySession() -> AVCaptureDevice.DiscoverySession {
-        // Include every macOS video device type that can surface a camera.
-        // Continuity Camera requires NSCameraUseContinuityCameraDeviceType in Info.plist
-        // and the .continuityCamera type (macOS 14+).
-        var deviceTypes: [AVCaptureDevice.DeviceType] = [
+    private static let videoDiscoverySession = AVCaptureDevice.DiscoverySession(
+        deviceTypes: [
             .builtInWideAngleCamera,
-            .external
-        ]
-
-        if #available(macOS 13.0, *) {
-            deviceTypes.append(.deskViewCamera)
-        }
-        if #available(macOS 14.0, *) {
-            deviceTypes.append(.continuityCamera)
-        }
-
-        return AVCaptureDevice.DiscoverySession(
-            deviceTypes: deviceTypes,
-            mediaType: .video,
-            position: .unspecified
-        )
-    }
+            .external,
+            .deskViewCamera,
+            .continuityCamera
+        ],
+        mediaType: .video,
+        position: .unspecified
+    )
 
     /// Cameras available for Mirror, sorted with built-in devices first.
     /// Includes Continuity Camera (iPhone/iPad), Desk View, USB webcams, and built-in FaceTime.
     static func availableCameras() -> [AVCaptureDevice] {
-        // Touch the retained session so it stays warm for connect/disconnect updates.
-        _ = videoDiscoverySession
-
-        var devicesByID: [String: AVCaptureDevice] = [:]
-
-        for device in videoDiscoverySession.devices {
-            devicesByID[device.uniqueID] = device
-        }
-
-        // Also merge a fresh session in case the retained one lags after permission grant.
-        for device in makeVideoDiscoverySession().devices {
-            devicesByID[device.uniqueID] = device
-        }
-
-        // Prefer/system cameras can surface Continuity Camera even when discovery is incomplete.
-        if #available(macOS 14.0, *) {
-            if let systemPreferred = AVCaptureDevice.systemPreferredCamera {
-                devicesByID[systemPreferred.uniqueID] = systemPreferred
-            }
-            if let userPreferred = AVCaptureDevice.userPreferredCamera {
-                devicesByID[userPreferred.uniqueID] = userPreferred
-            }
-            if let continuity = AVCaptureDevice.default(
-                .continuityCamera,
-                for: .video,
-                position: .unspecified
-            ) {
-                devicesByID[continuity.uniqueID] = continuity
-            }
-        }
-
-        if #available(macOS 13.0, *) {
-            if let deskView = AVCaptureDevice.default(
-                .deskViewCamera,
-                for: .video,
-                position: .unspecified
-            ) {
-                devicesByID[deskView.uniqueID] = deskView
-            }
-        }
-
-        if let builtIn = AVCaptureDevice.default(
-            .builtInWideAngleCamera,
-            for: .video,
-            position: .unspecified
-        ) {
-            devicesByID[builtIn.uniqueID] = builtIn
-        }
-
-        if let external = AVCaptureDevice.default(
-            .external,
-            for: .video,
-            position: .unspecified
-        ) {
-            devicesByID[external.uniqueID] = external
-        }
-
-        if let defaultVideo = AVCaptureDevice.default(for: .video) {
-            devicesByID[defaultVideo.uniqueID] = defaultVideo
-        }
-
-        return devicesByID.values.sorted { lhs, rhs in
+        videoDiscoverySession.devices.sorted { lhs, rhs in
             let lhsRank = cameraSortRank(for: lhs)
             let rhsRank = cameraSortRank(for: rhs)
             if lhsRank != rhsRank {
@@ -248,7 +173,7 @@ final class MirrorManager {
     static func displayName(for device: AVCaptureDevice) -> String {
         let name = device.localizedName
 
-        if #available(macOS 14.0, *), device.isContinuityCamera || device.deviceType == .continuityCamera {
+        if device.isContinuityCamera || device.deviceType == .continuityCamera {
             if name.localizedCaseInsensitiveContains("iphone")
                 || name.localizedCaseInsensitiveContains("ipad")
                 || name.localizedCaseInsensitiveContains("continuity") {
@@ -257,7 +182,7 @@ final class MirrorManager {
             return "\(name) (Continuity Camera)"
         }
 
-        if #available(macOS 13.0, *), device.deviceType == .deskViewCamera {
+        if device.deviceType == .deskViewCamera {
             if name.localizedCaseInsensitiveContains("desk") {
                 return name
             }
@@ -275,13 +200,11 @@ final class MirrorManager {
         if device.deviceType == .builtInWideAngleCamera {
             return 0
         }
-        if #available(macOS 13.0, *), device.deviceType == .deskViewCamera {
+        if device.deviceType == .deskViewCamera {
             return 3
         }
-        if #available(macOS 14.0, *) {
-            if device.isContinuityCamera || device.deviceType == .continuityCamera {
-                return 2
-            }
+        if device.isContinuityCamera || device.deviceType == .continuityCamera {
+            return 2
         }
         if device.deviceType == .external {
             return 2
@@ -289,22 +212,11 @@ final class MirrorManager {
         return 1
     }
 
-    private static func isContinuityOrExternal(_ device: AVCaptureDevice) -> Bool {
-        if #available(macOS 14.0, *), device.isContinuityCamera || device.deviceType == .continuityCamera {
-            return true
-        }
-        if #available(macOS 13.0, *), device.deviceType == .deskViewCamera {
-            return true
-        }
-        return device.deviceType == .external
-    }
-
     /// Restart Mirror if it's open so a newly chosen camera takes effect.
     func applyCameraSelectionChange() {
         guard isVisible else { return }
 
-        hide()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+        hide { [weak self] in
             self?.show()
         }
     }
@@ -319,16 +231,10 @@ final class MirrorManager {
             return selected
         }
 
-        // Automatic: prefer built-in FaceTime camera over Continuity Camera / external.
-        if let builtIn = devices.first(where: { $0.deviceType == .builtInWideAngleCamera }) {
-            return builtIn
-        }
-
-        if let nonExternal = devices.first(where: { !Self.isContinuityOrExternal($0) }) {
-            return nonExternal
-        }
-
-        return devices.first ?? AVCaptureDevice.default(for: .video)
+        // System Default follows the camera recommended by macOS.
+        return AVCaptureDevice.systemPreferredCamera
+            ?? AVCaptureDevice.default(for: .video)
+            ?? devices.first
     }
 
     private func configureUserSelectedVideoEffects(for camera: AVCaptureDevice) {

--- a/trace/Services/SettingsManager.swift
+++ b/trace/Services/SettingsManager.swift
@@ -22,7 +22,7 @@ struct TraceSettings: Codable {
     var accentColor: String = TraceAccent.system.rawValue
     var launcherVerticalPositionRatio: Double = TraceSettings.defaultLauncherVerticalPositionRatio
     var caffeinateFlags: String = CaffeinateManager.defaultFlags
-    /// Empty string means automatic camera selection (prefer built-in FaceTime camera).
+    /// Empty string means camera selection follows the macOS system preference.
     var mirrorCameraDeviceID: String = ""
     var dictationEnabled: Bool = false
     var dictationHotkey: String = ""

--- a/trace/Services/SettingsManager.swift
+++ b/trace/Services/SettingsManager.swift
@@ -583,6 +583,10 @@ class SettingsManager: ObservableObject {
                 settings.launcherVerticalPositionRatio = importedSettings.launcherVerticalPositionRatio
             }
 
+            if settings.mirrorCameraDeviceID.isEmpty {
+                settings.mirrorCameraDeviceID = importedSettings.mirrorCameraDeviceID
+            }
+
             // Main hotkey - only update if current is default
             if settings.mainHotkeyKeyCode == 49 && settings.mainHotkeyModifiers == 2048 {
                 settings.mainHotkeyKeyCode = importedSettings.mainHotkeyKeyCode

--- a/trace/Services/SettingsManager.swift
+++ b/trace/Services/SettingsManager.swift
@@ -22,6 +22,8 @@ struct TraceSettings: Codable {
     var accentColor: String = TraceAccent.system.rawValue
     var launcherVerticalPositionRatio: Double = TraceSettings.defaultLauncherVerticalPositionRatio
     var caffeinateFlags: String = CaffeinateManager.defaultFlags
+    /// Empty string means automatic camera selection (prefer built-in FaceTime camera).
+    var mirrorCameraDeviceID: String = ""
     var dictationEnabled: Bool = false
     var dictationHotkey: String = ""
     var dictationHotkeyKeyCode: Int = 0
@@ -60,6 +62,7 @@ struct TraceSettings: Codable {
             try container.decodeIfPresent(Double.self, forKey: .launcherVerticalPositionRatio) ?? Self.defaultLauncherVerticalPositionRatio
         )
         caffeinateFlags = try container.decodeIfPresent(String.self, forKey: .caffeinateFlags) ?? CaffeinateManager.defaultFlags
+        mirrorCameraDeviceID = try container.decodeIfPresent(String.self, forKey: .mirrorCameraDeviceID) ?? ""
         dictationEnabled = try container.decodeIfPresent(Bool.self, forKey: .dictationEnabled) ?? false
         dictationHotkey = try container.decodeIfPresent(String.self, forKey: .dictationHotkey) ?? ""
         dictationHotkeyKeyCode = try container.decodeIfPresent(Int.self, forKey: .dictationHotkeyKeyCode) ?? 0
@@ -404,6 +407,13 @@ class SettingsManager: ObservableObject {
         guard settings.caffeinateFlags != flags else { return }
 
         settings.caffeinateFlags = flags
+        saveSettings()
+    }
+
+    func updateMirrorCameraDeviceID(_ deviceID: String) {
+        guard settings.mirrorCameraDeviceID != deviceID else { return }
+
+        settings.mirrorCameraDeviceID = deviceID
         saveSettings()
     }
 

--- a/trace/Views/Settings/GeneralSettingsView.swift
+++ b/trace/Views/Settings/GeneralSettingsView.swift
@@ -184,7 +184,7 @@ struct GeneralSettingsView: View {
                     subtitle: mirrorCameraSubtitle
                 ) {
                     Picker("", selection: $selectedMirrorCameraID) {
-                        Text("Automatic (Built-in)").tag("")
+                        Text("System Default").tag("")
 
                         ForEach(availableMirrorCameras, id: \.uniqueID) { device in
                             Text(MirrorManager.displayName(for: device)).tag(device.uniqueID)
@@ -198,8 +198,10 @@ struct GeneralSettingsView: View {
                     }
                     .pickerStyle(.menu)
                     .frame(minWidth: 200, maxWidth: 260)
-                    .disabled(cameraAuthorizationStatus != .authorized && availableMirrorCameras.isEmpty)
+                    .disabled(cameraAuthorizationStatus != .authorized)
                     .onChange(of: selectedMirrorCameraID) { _, newValue in
+                        guard newValue != settingsManager.settings.mirrorCameraDeviceID else { return }
+
                         settingsManager.updateMirrorCameraDeviceID(newValue)
                         Task { @MainActor in
                             ServiceContainer.shared.mirrorManager.applyCameraSelectionChange()
@@ -207,7 +209,7 @@ struct GeneralSettingsView: View {
                     }
                 }
             } footer: {
-                Text("Choose which camera Mirror uses. Automatic prefers the built-in FaceTime camera. Continuity Camera (iPhone/iPad) appears when the device is nearby, unlocked, and camera access is granted.")
+                Text("Choose which camera Mirror uses. System Default follows the camera recommended by macOS. Continuity Camera (iPhone/iPad) appears when the device is nearby, unlocked, and camera access is granted.")
             }
 
             NativeSettingsSection("Interface") {
@@ -629,16 +631,15 @@ struct GeneralSettingsView: View {
         if availableMirrorCameras.isEmpty {
             return "No cameras detected"
         }
+        let cameraCount = availableMirrorCameras.count
+        let cameraLabel = cameraCount == 1 ? "camera" : "cameras"
         let continuityCount = availableMirrorCameras.filter {
-            if #available(macOS 14.0, *) {
-                return $0.isContinuityCamera || $0.deviceType == .continuityCamera
-            }
-            return false
+            $0.isContinuityCamera || $0.deviceType == .continuityCamera
         }.count
         if continuityCount > 0 {
-            return "\(availableMirrorCameras.count) cameras · includes Continuity Camera"
+            return "\(cameraCount) \(cameraLabel) · includes Continuity Camera"
         }
-        return "\(availableMirrorCameras.count) cameras available for Mirror"
+        return "\(cameraCount) \(cameraLabel) available for Mirror"
     }
 
     private func checkCameraPermissions() {

--- a/trace/Views/Settings/GeneralSettingsView.swift
+++ b/trace/Views/Settings/GeneralSettingsView.swift
@@ -40,6 +40,8 @@ struct GeneralSettingsView: View {
     @State private var checkingPermissions = false
     @State private var requestingCalendarPermission = false
     @State private var requestingCameraPermission = false
+    @State private var availableMirrorCameras: [AVCaptureDevice] = []
+    @State private var selectedMirrorCameraID: String = ""
     let onLaunchAtLoginChange: (Bool) -> Void
     let onHotkeyRecord: (UInt32, UInt32) -> Void
     let onHotkeyReset: () -> Void
@@ -174,6 +176,38 @@ struct GeneralSettingsView: View {
                 .frame(minHeight: 44)
             } footer: {
                 Text("All permissions are optional. Features that need a permission may be unavailable until you grant it, and you can change access any time in System Settings.")
+            }
+
+            NativeSettingsSection("Mirror") {
+                NativeSettingsRow(
+                    title: "Camera",
+                    subtitle: mirrorCameraSubtitle
+                ) {
+                    Picker("", selection: $selectedMirrorCameraID) {
+                        Text("Automatic (Built-in)").tag("")
+
+                        ForEach(availableMirrorCameras, id: \.uniqueID) { device in
+                            Text(MirrorManager.displayName(for: device)).tag(device.uniqueID)
+                        }
+
+                        // Keep a previously saved camera visible if it is currently disconnected.
+                        if !selectedMirrorCameraID.isEmpty,
+                           !availableMirrorCameras.contains(where: { $0.uniqueID == selectedMirrorCameraID }) {
+                            Text("Unavailable camera").tag(selectedMirrorCameraID)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(minWidth: 200, maxWidth: 260)
+                    .disabled(cameraAuthorizationStatus != .authorized && availableMirrorCameras.isEmpty)
+                    .onChange(of: selectedMirrorCameraID) { _, newValue in
+                        settingsManager.updateMirrorCameraDeviceID(newValue)
+                        Task { @MainActor in
+                            ServiceContainer.shared.mirrorManager.applyCameraSelectionChange()
+                        }
+                    }
+                }
+            } footer: {
+                Text("Choose which camera Mirror uses. Automatic prefers the built-in FaceTime camera. Continuity Camera (iPhone/iPad) appears when the device is nearby, unlocked, and camera access is granted.")
             }
 
             NativeSettingsSection("Interface") {
@@ -319,9 +353,17 @@ struct GeneralSettingsView: View {
             resultsLayout = ResultsLayout(rawValue: settingsManager.settings.resultsLayout) ?? .compact
             showMenuBarIcon = settingsManager.settings.showMenuBarIcon
             accentColor = settingsManager.selectedAccent
+            selectedMirrorCameraID = settingsManager.settings.mirrorCameraDeviceID
+            refreshAvailableMirrorCameras()
             
             // Check permissions
             checkPermissions()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AVCaptureDevice.wasConnectedNotification)) { _ in
+            refreshAvailableMirrorCameras()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AVCaptureDevice.wasDisconnectedNotification)) { _ in
+            refreshAvailableMirrorCameras()
         }
         .onDisappear {
             stopRecording()
@@ -580,8 +622,32 @@ struct GeneralSettingsView: View {
         cameraAuthorizationStatus == .notDetermined ? "Request Permission" : "Open Settings"
     }
 
+    private var mirrorCameraSubtitle: String {
+        if cameraAuthorizationStatus != .authorized {
+            return "Grant camera access to choose a Mirror camera"
+        }
+        if availableMirrorCameras.isEmpty {
+            return "No cameras detected"
+        }
+        let continuityCount = availableMirrorCameras.filter {
+            if #available(macOS 14.0, *) {
+                return $0.isContinuityCamera || $0.deviceType == .continuityCamera
+            }
+            return false
+        }.count
+        if continuityCount > 0 {
+            return "\(availableMirrorCameras.count) cameras · includes Continuity Camera"
+        }
+        return "\(availableMirrorCameras.count) cameras available for Mirror"
+    }
+
     private func checkCameraPermissions() {
         cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        refreshAvailableMirrorCameras()
+    }
+
+    private func refreshAvailableMirrorCameras() {
+        availableMirrorCameras = MirrorManager.availableCameras()
     }
 
     private func requestCameraPermission() {
@@ -593,6 +659,7 @@ struct GeneralSettingsView: View {
             await MainActor.run {
                 cameraAuthorizationStatus = granted ? .authorized : AVCaptureDevice.authorizationStatus(for: .video)
                 requestingCameraPermission = false
+                refreshAvailableMirrorCameras()
             }
         }
     }

--- a/trace/Views/Settings/GeneralSettingsView.swift
+++ b/trace/Views/Settings/GeneralSettingsView.swift
@@ -41,7 +41,6 @@ struct GeneralSettingsView: View {
     @State private var requestingCalendarPermission = false
     @State private var requestingCameraPermission = false
     @State private var availableMirrorCameras: [AVCaptureDevice] = []
-    @State private var selectedMirrorCameraID: String = ""
     let onLaunchAtLoginChange: (Bool) -> Void
     let onHotkeyRecord: (UInt32, UInt32) -> Void
     let onHotkeyReset: () -> Void
@@ -183,7 +182,10 @@ struct GeneralSettingsView: View {
                     title: "Camera",
                     subtitle: mirrorCameraSubtitle
                 ) {
-                    Picker("", selection: $selectedMirrorCameraID) {
+                    Picker("", selection: Binding(
+                        get: { settingsManager.settings.mirrorCameraDeviceID },
+                        set: { settingsManager.updateMirrorCameraDeviceID($0) }
+                    )) {
                         Text("System Default").tag("")
 
                         ForEach(availableMirrorCameras, id: \.uniqueID) { device in
@@ -191,22 +193,16 @@ struct GeneralSettingsView: View {
                         }
 
                         // Keep a previously saved camera visible if it is currently disconnected.
-                        if !selectedMirrorCameraID.isEmpty,
-                           !availableMirrorCameras.contains(where: { $0.uniqueID == selectedMirrorCameraID }) {
-                            Text("Unavailable camera").tag(selectedMirrorCameraID)
+                        if !settingsManager.settings.mirrorCameraDeviceID.isEmpty,
+                           !availableMirrorCameras.contains(where: {
+                               $0.uniqueID == settingsManager.settings.mirrorCameraDeviceID
+                           }) {
+                            Text("Unavailable camera").tag(settingsManager.settings.mirrorCameraDeviceID)
                         }
                     }
                     .pickerStyle(.menu)
                     .frame(minWidth: 200, maxWidth: 260)
                     .disabled(cameraAuthorizationStatus != .authorized)
-                    .onChange(of: selectedMirrorCameraID) { _, newValue in
-                        guard newValue != settingsManager.settings.mirrorCameraDeviceID else { return }
-
-                        settingsManager.updateMirrorCameraDeviceID(newValue)
-                        Task { @MainActor in
-                            ServiceContainer.shared.mirrorManager.applyCameraSelectionChange()
-                        }
-                    }
                 }
             } footer: {
                 Text("Choose which camera Mirror uses. System Default follows the camera recommended by macOS. Continuity Camera (iPhone/iPad) appears when the device is nearby, unlocked, and camera access is granted.")
@@ -355,7 +351,6 @@ struct GeneralSettingsView: View {
             resultsLayout = ResultsLayout(rawValue: settingsManager.settings.resultsLayout) ?? .compact
             showMenuBarIcon = settingsManager.settings.showMenuBarIcon
             accentColor = settingsManager.selectedAccent
-            selectedMirrorCameraID = settingsManager.settings.mirrorCameraDeviceID
             refreshAvailableMirrorCameras()
             
             // Check permissions
@@ -366,6 +361,11 @@ struct GeneralSettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: AVCaptureDevice.wasDisconnectedNotification)) { _ in
             refreshAvailableMirrorCameras()
+        }
+        .onChange(of: settingsManager.settings.mirrorCameraDeviceID) { _, _ in
+            Task { @MainActor in
+                ServiceContainer.shared.mirrorManager.applyCameraSelectionChange()
+            }
         }
         .onDisappear {
             stopRecording()


### PR DESCRIPTION
Let users pick which camera Mirror uses in General settings, prefer the built-in FaceTime camera by default, and properly discover Continuity Camera (iPhone).