### PR TITLE
Add toggles for which search result sources to show

### DIFF
--- a/trace/Models/SearchModels.swift
+++ b/trace/Models/SearchModels.swift
@@ -33,6 +33,92 @@ enum ResultsLayout: String, CaseIterable {
     }
 }
 
+/// Toggleable search result sources shown in Settings → Interface.
+/// Each case maps to a result provider in the launcher search pipeline.
+enum SearchResultSource: String, CaseIterable, Codable, Identifiable {
+    case applications
+    case commands
+    case network
+    case systemSettings
+    case windowManagement
+    case quickLinks
+    case calendar
+    case emoji
+    case math
+    case webSearch
+    case menuItems
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .applications:
+            return "Applications"
+        case .commands:
+            return "Commands"
+        case .network:
+            return "Network"
+        case .systemSettings:
+            return "System Settings"
+        case .windowManagement:
+            return "Window Management"
+        case .quickLinks:
+            return "Quick Links"
+        case .calendar:
+            return "Calendar"
+        case .emoji:
+            return "Emoji"
+        case .math:
+            return "Math"
+        case .webSearch:
+            return "Web Search"
+        case .menuItems:
+            return "Menu Items"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .applications:
+            return "Installed apps and launch results"
+        case .commands:
+            return "Trace commands like Settings, Quit, Caffeinate, and Mirror"
+        case .network:
+            return "Public and private IP lookup commands"
+        case .systemSettings:
+            return "Control Center and system preference shortcuts"
+        case .windowManagement:
+            return "Window snap, resize, and position commands"
+        case .quickLinks:
+            return "Custom folders, files, and link shortcuts"
+        case .calendar:
+            return "Calendar events from EventKit"
+        case .emoji:
+            return "Emoji search and copy results"
+        case .math:
+            return "Inline math expression results"
+        case .webSearch:
+            return "Google, DuckDuckGo, and Perplexity suggestions"
+        case .menuItems:
+            return "Menu bar items from the frontmost app"
+        }
+    }
+
+    /// Defaults: every source enabled.
+    static var defaultEnabledMap: [String: Bool] {
+        Dictionary(uniqueKeysWithValues: allCases.map { ($0.rawValue, true) })
+    }
+
+    /// Merge saved values with defaults so new sources stay on when added later.
+    static func mergedWithDefaults(_ saved: [String: Bool]) -> [String: Bool] {
+        var merged = defaultEnabledMap
+        for (key, value) in saved {
+            merged[key] = value
+        }
+        return merged
+    }
+}
+
 enum SearchResultType {
     case application
     case command

--- a/trace/Models/SearchModels.swift
+++ b/trace/Models/SearchModels.swift
@@ -37,7 +37,6 @@ enum ResultsLayout: String, CaseIterable {
 /// Each case maps to a result provider in the launcher search pipeline.
 enum SearchResultSource: String, CaseIterable, Codable, Identifiable {
     case applications
-    case commands
     case network
     case systemSettings
     case windowManagement
@@ -54,8 +53,6 @@ enum SearchResultSource: String, CaseIterable, Codable, Identifiable {
         switch self {
         case .applications:
             return "Applications"
-        case .commands:
-            return "Commands"
         case .network:
             return "Network"
         case .systemSettings:
@@ -73,7 +70,7 @@ enum SearchResultSource: String, CaseIterable, Codable, Identifiable {
         case .webSearch:
             return "Web Search"
         case .menuItems:
-            return "Menu Items"
+            return "Search Menu Items"
         }
     }
 
@@ -81,8 +78,6 @@ enum SearchResultSource: String, CaseIterable, Codable, Identifiable {
         switch self {
         case .applications:
             return "Installed apps and launch results"
-        case .commands:
-            return "Trace commands like Settings, Quit, Caffeinate, and Mirror"
         case .network:
             return "Public and private IP lookup commands"
         case .systemSettings:
@@ -104,9 +99,11 @@ enum SearchResultSource: String, CaseIterable, Codable, Identifiable {
         }
     }
 
-    /// Defaults: every source enabled.
+    /// Defaults: every source enabled except Calendar, which remains opt-in.
     static var defaultEnabledMap: [String: Bool] {
-        Dictionary(uniqueKeysWithValues: allCases.map { ($0.rawValue, true) })
+        Dictionary(uniqueKeysWithValues: allCases.map { source in
+            (source.rawValue, source != .calendar)
+        })
     }
 
     /// Merge saved values with defaults so new sources stay on when added later.

--- a/trace/Search/Providers/CalendarResultProvider.swift
+++ b/trace/Search/Providers/CalendarResultProvider.swift
@@ -12,7 +12,7 @@ class CalendarResultProvider: ResultProvider {
     
     func getResults(for query: String, context: SearchContext) async -> [(SearchResult, Double)] {
         // Only return results if calendar search is enabled
-        guard context.services.settingsManager.settings.calendarSearchEnabled else {
+        guard context.services.settingsManager.isSearchResultSourceEnabled(.calendar) else {
             return []
         }
         

--- a/trace/Services/SettingsManager.swift
+++ b/trace/Services/SettingsManager.swift
@@ -19,6 +19,8 @@ struct TraceSettings: Codable {
     var launchAtLogin: Bool = false
     var hasCompletedOnboarding: Bool = false
     var calendarSearchEnabled: Bool = false
+    /// Per-source visibility in launcher search. Missing keys default to enabled.
+    var enabledSearchResultSources: [String: Bool] = SearchResultSource.defaultEnabledMap
     var accentColor: String = TraceAccent.system.rawValue
     var launcherVerticalPositionRatio: Double = TraceSettings.defaultLauncherVerticalPositionRatio
     var caffeinateFlags: String = CaffeinateManager.defaultFlags
@@ -55,6 +57,13 @@ struct TraceSettings: Codable {
         launchAtLogin = try container.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? false
         hasCompletedOnboarding = try container.decodeIfPresent(Bool.self, forKey: .hasCompletedOnboarding) ?? false
         calendarSearchEnabled = try container.decodeIfPresent(Bool.self, forKey: .calendarSearchEnabled) ?? false
+        if let savedSources = try container.decodeIfPresent([String: Bool].self, forKey: .enabledSearchResultSources) {
+            enabledSearchResultSources = SearchResultSource.mergedWithDefaults(savedSources)
+        } else {
+            // Existing installs: keep previous calendar preference, enable everything else.
+            enabledSearchResultSources = SearchResultSource.defaultEnabledMap
+            enabledSearchResultSources[SearchResultSource.calendar.rawValue] = calendarSearchEnabled
+        }
         accentColor = try container.decodeIfPresent(String.self, forKey: .accentColor) ?? TraceAccent.system.rawValue
         launcherVerticalPositionRatio = Self.clampLauncherVerticalPositionRatio(
             try container.decodeIfPresent(Double.self, forKey: .launcherVerticalPositionRatio) ?? Self.defaultLauncherVerticalPositionRatio
@@ -380,6 +389,27 @@ class SettingsManager: ObservableObject {
     
     func updateCalendarSearchEnabled(_ enabled: Bool) {
         settings.calendarSearchEnabled = enabled
+        settings.enabledSearchResultSources[SearchResultSource.calendar.rawValue] = enabled
+        saveSettings()
+    }
+
+    func isSearchResultSourceEnabled(_ source: SearchResultSource) -> Bool {
+        if source == .calendar {
+            // Keep calendar in sync with the legacy flag used elsewhere.
+            return settings.enabledSearchResultSources[source.rawValue]
+                ?? settings.calendarSearchEnabled
+        }
+        return settings.enabledSearchResultSources[source.rawValue] ?? true
+    }
+
+    func updateSearchResultSource(_ source: SearchResultSource, enabled: Bool) {
+        let currentlyEnabled = isSearchResultSourceEnabled(source)
+        guard currentlyEnabled != enabled else { return }
+
+        settings.enabledSearchResultSources[source.rawValue] = enabled
+        if source == .calendar {
+            settings.calendarSearchEnabled = enabled
+        }
         saveSettings()
     }
     

--- a/trace/Views/LauncherSearchLogic.swift
+++ b/trace/Views/LauncherSearchLogic.swift
@@ -109,6 +109,9 @@ extension LauncherView {
         let runningApps = services.appSearchManager.getRunningAppBundleIds()
 
         if MenuItemProvider.isScoped(query) {
+            guard services.settingsManager.isSearchResultSourceEnabled(.menuItems) else {
+                return []
+            }
             let context = SearchContext(
                 query: query,
                 services: services,
@@ -131,24 +134,49 @@ extension LauncherView {
         )
     }
     
-    /// Create search coordinator with all providers
+    /// Create search coordinator with only enabled result sources
     private func createSearchCoordinator() -> SearchCoordinator {
-        let providers: [ResultProvider] = [
-            AppResultProvider(),
-            createMenuItemProvider(),
-            SystemCommandProvider(
-                clearSearch: clearSearch,
-                onClose: onClose
-            ),
-            NetworkCommandProvider(),
-            ControlCenterProvider(),
-            WindowManagementProvider(),
-            QuickLinksProvider(),
-            CalendarResultProvider(),
-            EmojiResultProvider(),
-            MathResultProvider(),
-            SearchEngineProvider()
-        ]
+        let settings = services.settingsManager
+        var providers: [ResultProvider] = []
+
+        if settings.isSearchResultSourceEnabled(.applications) {
+            providers.append(AppResultProvider())
+        }
+        if settings.isSearchResultSourceEnabled(.menuItems) {
+            providers.append(createMenuItemProvider())
+        }
+        if settings.isSearchResultSourceEnabled(.commands) {
+            providers.append(
+                SystemCommandProvider(
+                    clearSearch: clearSearch,
+                    onClose: onClose
+                )
+            )
+        }
+        if settings.isSearchResultSourceEnabled(.network) {
+            providers.append(NetworkCommandProvider())
+        }
+        if settings.isSearchResultSourceEnabled(.systemSettings) {
+            providers.append(ControlCenterProvider())
+        }
+        if settings.isSearchResultSourceEnabled(.windowManagement) {
+            providers.append(WindowManagementProvider())
+        }
+        if settings.isSearchResultSourceEnabled(.quickLinks) {
+            providers.append(QuickLinksProvider())
+        }
+        if settings.isSearchResultSourceEnabled(.calendar) {
+            providers.append(CalendarResultProvider())
+        }
+        if settings.isSearchResultSourceEnabled(.emoji) {
+            providers.append(EmojiResultProvider())
+        }
+        if settings.isSearchResultSourceEnabled(.math) {
+            providers.append(MathResultProvider())
+        }
+        if settings.isSearchResultSourceEnabled(.webSearch) {
+            providers.append(SearchEngineProvider())
+        }
         
         return SearchCoordinator(providers: providers)
     }

--- a/trace/Views/LauncherSearchLogic.swift
+++ b/trace/Views/LauncherSearchLogic.swift
@@ -145,14 +145,13 @@ extension LauncherView {
         if settings.isSearchResultSourceEnabled(.menuItems) {
             providers.append(createMenuItemProvider())
         }
-        if settings.isSearchResultSourceEnabled(.commands) {
-            providers.append(
-                SystemCommandProvider(
-                    clearSearch: clearSearch,
-                    onClose: onClose
-                )
+        // Commands are always available, including Trace Settings and Quit.
+        providers.append(
+            SystemCommandProvider(
+                clearSearch: clearSearch,
+                onClose: onClose
             )
-        }
+        )
         if settings.isSearchResultSourceEnabled(.network) {
             providers.append(NetworkCommandProvider())
         }

--- a/trace/Views/Settings/GeneralSettingsView.swift
+++ b/trace/Views/Settings/GeneralSettingsView.swift
@@ -178,24 +178,6 @@ struct GeneralSettingsView: View {
 
             NativeSettingsSection("Interface") {
                 NativeSettingsRow(
-                    title: "Results Layout",
-                    subtitle: "Choose how search results are displayed"
-                ) {
-                    Picker("", selection: $resultsLayout) {
-                        ForEach(ResultsLayout.allCases, id: \.self) { layout in
-                            Text(layout.displayName).tag(layout)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .frame(width: 140)
-                    .onChange(of: resultsLayout) { _, newValue in
-                        settingsManager.updateResultsLayout(newValue.rawValue)
-                    }
-                }
-                
-                NativeSettingsDivider()
-                
-                NativeSettingsRow(
                     title: "Accent Color",
                     subtitle: "Tint Trace foregrounds and Liquid Glass surfaces",
                     minHeight: 66
@@ -264,26 +246,47 @@ struct GeneralSettingsView: View {
                             settingsManager.updateShowMenuBarIcon(newValue)
                         }
                 }
-                
-                NativeSettingsDivider()
-                
+            }
+
+            NativeSettingsSection("Search Results") {
                 NativeSettingsRow(
-                    title: "Calendar Search",
-                    subtitle: "Search and open calendar events"
+                    title: "Results Layout",
+                    subtitle: "Choose how search results are displayed"
                 ) {
-                    Toggle("", isOn: Binding(
-                        get: { settingsManager.settings.calendarSearchEnabled },
-                        set: { newValue in
-                            settingsManager.updateCalendarSearchEnabled(newValue)
-                            if newValue && !calendarEnabled {
-                                requestCalendarPermission()
-                            }
+                    Picker("", selection: $resultsLayout) {
+                        ForEach(ResultsLayout.allCases, id: \.self) { layout in
+                            Text(layout.displayName).tag(layout)
                         }
-                    ))
-                    .toggleStyle(.switch)
-                    .labelsHidden()
-                    .disabled(!calendarEnabled)
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 140)
+                    .onChange(of: resultsLayout) { _, newValue in
+                        settingsManager.updateResultsLayout(newValue.rawValue)
+                    }
                 }
+
+                ForEach(Array(SearchResultSource.allCases.enumerated()), id: \.element.id) { _, source in
+                    NativeSettingsDivider()
+
+                    NativeSettingsRow(
+                        title: source.displayName,
+                        subtitle: source.subtitle
+                    ) {
+                        Toggle("", isOn: Binding(
+                            get: { settingsManager.isSearchResultSourceEnabled(source) },
+                            set: { newValue in
+                                settingsManager.updateSearchResultSource(source, enabled: newValue)
+                                if source == .calendar, newValue, !calendarEnabled {
+                                    requestCalendarPermission()
+                                }
+                            }
+                        ))
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                    }
+                }
+            } footer: {
+                Text("Choose which result types appear in Trace search. All sources are enabled by default.")
             }
             
             NativeSettingsSection("Settings Backup") {

--- a/trace/Views/Settings/GeneralSettingsView.swift
+++ b/trace/Views/Settings/GeneralSettingsView.swift
@@ -265,7 +265,7 @@ struct GeneralSettingsView: View {
                     }
                 }
 
-                ForEach(Array(SearchResultSource.allCases.enumerated()), id: \.element.id) { _, source in
+                ForEach(SearchResultSource.allCases) { source in
                     NativeSettingsDivider()
 
                     NativeSettingsRow(
@@ -286,7 +286,7 @@ struct GeneralSettingsView: View {
                     }
                 }
             } footer: {
-                Text("Choose which result types appear in Trace search. All sources are enabled by default.")
+                Text("Choose which result types appear in Trace search. Calendar search is opt-in and requires permission.")
             }
             
             NativeSettingsSection("Settings Backup") {
@@ -614,6 +614,9 @@ struct GeneralSettingsView: View {
                 if granted {
                     // Automatically enable calendar search when permission is granted
                     settingsManager.updateCalendarSearchEnabled(true)
+                } else {
+                    // Do not show Calendar as enabled when EventKit access was denied.
+                    settingsManager.updateSearchResultSource(.calendar, enabled: false)
                 }
             }
         }


### PR DESCRIPTION
Add a Search Results settings section with per-source switches for apps, commands, network, system settings, window management, quick links, calendar, emoji, math, web search, and menu items. 

All sources default to enabled, and disabled providers are skipped during search.