### PR TITLE
Show launcher and Mirror on the active window's screen

### DIFF
--- a/trace/Services/MirrorManager.swift
+++ b/trace/Services/MirrorManager.swift
@@ -91,6 +91,7 @@ final class MirrorManager {
 
     private func showAuthorizedMirror() {
         if let mirrorWindow, mirrorWindow.isVisible {
+            mirrorWindow.repositionOnActiveScreen()
             mirrorWindow.orderFrontRegardless()
             scheduleAutoHide()
             return

--- a/trace/Utils/NSScreen+Active.swift
+++ b/trace/Utils/NSScreen+Active.swift
@@ -1,0 +1,115 @@
+//
+//  NSScreen+Active.swift
+//  trace
+//
+
+import AppKit
+import CoreGraphics
+
+extension NSScreen {
+    /// Screen that contains the focused/frontmost window of the app the user was
+    /// working in (before Trace became frontmost). Prefer this over `NSScreen.main`
+    /// for UI that should appear where the user is working.
+    ///
+    /// Resolution order:
+    /// 1. Screen containing the active window of `lastActiveApplication` / frontmost app
+    /// 2. Screen under the mouse cursor
+    /// 3. Main screen / first screen
+    static var active: NSScreen? {
+        screenContainingActiveWindow()
+            ?? screenContainingMouse()
+            ?? main
+            ?? screens.first
+    }
+
+    // MARK: - Active window screen
+
+    /// Screen that contains the frontmost on-screen window of the target app.
+    private static func screenContainingActiveWindow() -> NSScreen? {
+        guard let targetPID = targetApplicationPID() else { return nil }
+
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return nil
+        }
+
+        // Window list is front-to-back; first layer-0 window of the target app is its active window.
+        for info in windowList {
+            guard let ownerPID = info[kCGWindowOwnerPID as String] as? pid_t,
+                  ownerPID == targetPID else {
+                continue
+            }
+
+            let layer = info[kCGWindowLayer as String] as? Int ?? -1
+            guard layer == 0 else { continue }
+
+            guard let boundsDict = info[kCGWindowBounds as String] as? NSDictionary else {
+                continue
+            }
+
+            var cgFrame = CGRect.zero
+            guard CGRectMakeWithDictionaryRepresentation(boundsDict, &cgFrame),
+                  cgFrame.width > 1, cgFrame.height > 1 else {
+                continue
+            }
+
+            let appKitFrame = convertCGFrameToAppKit(cgFrame)
+            let center = CGPoint(x: appKitFrame.midX, y: appKitFrame.midY)
+
+            if let screen = screens.first(where: { NSMouseInRect(center, $0.frame, false) }) {
+                return screen
+            }
+
+            // Fallback: largest intersection with any screen (window straddling monitors)
+            return screens.max(by: {
+                $0.frame.intersection(appKitFrame).area < $1.frame.intersection(appKitFrame).area
+            })
+        }
+
+        return nil
+    }
+
+    /// App whose window should define the "active" screen — last app before Trace,
+    /// or the current frontmost app when it isn't Trace.
+    private static func targetApplicationPID() -> pid_t? {
+        if let lastApp = PermissionManager.shared.lastActiveApplication {
+            return lastApp.processIdentifier
+        }
+
+        if let frontmost = NSWorkspace.shared.frontmostApplication,
+           frontmost.bundleIdentifier != Bundle.main.bundleIdentifier {
+            return frontmost.processIdentifier
+        }
+
+        return nil
+    }
+
+    // MARK: - Coordinate conversion
+
+    /// Converts a CoreGraphics / window-server frame (origin top-left of main display)
+    /// into AppKit coordinates (origin bottom-left of main display).
+    private static func convertCGFrameToAppKit(_ cgFrame: CGRect) -> CGRect {
+        let mainDisplayHeight = CGDisplayBounds(CGMainDisplayID()).height
+        return CGRect(
+            x: cgFrame.origin.x,
+            y: mainDisplayHeight - cgFrame.origin.y - cgFrame.height,
+            width: cgFrame.width,
+            height: cgFrame.height
+        )
+    }
+
+    // MARK: - Cursor fallback
+
+    private static func screenContainingMouse() -> NSScreen? {
+        let mouseLocation = NSEvent.mouseLocation
+        return screens.first { NSMouseInRect(mouseLocation, $0.frame, false) }
+    }
+}
+
+private extension CGRect {
+    var area: CGFloat {
+        max(0, width) * max(0, height)
+    }
+}

--- a/trace/Windows/LauncherWindow.swift
+++ b/trace/Windows/LauncherWindow.swift
@@ -90,7 +90,7 @@ class LauncherWindow: NSPanel {
     }
     
     override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
-        guard let screen = screen ?? self.screen ?? NSScreen.main else {
+        guard let screen = screen ?? self.screen ?? NSScreen.active else {
             return super.constrainFrameRect(frameRect, to: screen)
         }
         
@@ -171,7 +171,8 @@ class LauncherWindow: NSPanel {
     }
     
     private func positionOnScreen() {
-        guard let screen = NSScreen.main else { return }
+        // Place the launcher on the screen with the active window, not always the main display.
+        guard let screen = NSScreen.active else { return }
         resizeToFitContent()
         
         let nextFrame = frame(
@@ -188,7 +189,7 @@ class LauncherWindow: NSPanel {
     
     @objc private func windowDidMove() {
         guard isVisible, !isApplyingSavedPosition else { return }
-        guard let screen = screen ?? NSScreen.main else { return }
+        guard let screen = screen ?? NSScreen.active else { return }
         
         let constrainedFrame = horizontallyCenteredFrame(frame, on: screen)
         if frame.origin != constrainedFrame.origin {
@@ -204,7 +205,7 @@ class LauncherWindow: NSPanel {
 
     @objc private func launcherContentSizeDidChange() {
         guard isVisible else { return }
-        guard let screen = screen ?? NSScreen.main else { return }
+        guard let screen = screen ?? NSScreen.active else { return }
 
         let previousMaxY = frame.maxY
         savePositionWorkItem?.cancel()

--- a/trace/Windows/MirrorWindow.swift
+++ b/trace/Windows/MirrorWindow.swift
@@ -17,6 +17,7 @@ final class MirrorWindow: NSPanel {
 
     private let onClose: () -> Void
     private var isAnimatingOut = false
+    private var targetScreen: NSScreen?
 
     init(session: AVCaptureSession, onClose: @escaping () -> Void) {
         self.onClose = onClose
@@ -58,8 +59,11 @@ final class MirrorWindow: NSPanel {
     }
 
     func show() {
-        let finalFrame = windowFrame(for: Layout.windowSize)
-        let initialFrame = windowFrame(for: Layout.collapsedSize)
+        let selectedScreen = NSScreen.active
+        targetScreen = selectedScreen
+
+        let finalFrame = windowFrame(for: Layout.windowSize, on: selectedScreen)
+        let initialFrame = windowFrame(for: Layout.collapsedSize, on: selectedScreen)
         setFrame(
             NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? finalFrame : initialFrame,
             display: true
@@ -80,6 +84,13 @@ final class MirrorWindow: NSPanel {
         }
     }
 
+    func repositionOnActiveScreen() {
+        guard let selectedScreen = NSScreen.active else { return }
+
+        targetScreen = selectedScreen
+        setFrame(windowFrame(for: Layout.windowSize, on: selectedScreen), display: true)
+    }
+
     func hide(notify: Bool = true, completion: (() -> Void)? = nil) {
         if notify {
             onClose()
@@ -92,6 +103,9 @@ final class MirrorWindow: NSPanel {
         }
         isAnimatingOut = true
 
+        let selectedScreen = screen ?? targetScreen ?? NSScreen.active
+        let collapsedFrame = windowFrame(for: Layout.collapsedSize, on: selectedScreen)
+
         let completionHandler = { [weak self] in
             self?.orderOut(nil)
             self?.setIsVisible(false)
@@ -101,7 +115,7 @@ final class MirrorWindow: NSPanel {
 
         guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else {
             alphaValue = 0
-            setFrame(windowFrame(for: Layout.collapsedSize), display: true)
+            setFrame(collapsedFrame, display: true)
             completionHandler()
             return
         }
@@ -110,7 +124,7 @@ final class MirrorWindow: NSPanel {
             context.duration = 0.18
             context.timingFunction = CAMediaTimingFunction(name: .easeIn)
             animator().alphaValue = 0
-            animator().setFrame(windowFrame(for: Layout.collapsedSize), display: true)
+            animator().setFrame(collapsedFrame, display: true)
         }, completionHandler: completionHandler)
     }
 
@@ -135,9 +149,8 @@ final class MirrorWindow: NSPanel {
         contentView = MirrorPreviewView(session: session, onClose: onClose)
     }
 
-    private func windowFrame(for size: NSSize) -> NSRect {
-        // Place Mirror on the screen with the active window, not always the main display.
-        guard let screen = NSScreen.active else {
+    private func windowFrame(for size: NSSize, on screen: NSScreen?) -> NSRect {
+        guard let screen else {
             return NSRect(origin: .zero, size: size)
         }
 

--- a/trace/Windows/MirrorWindow.swift
+++ b/trace/Windows/MirrorWindow.swift
@@ -136,8 +136,8 @@ final class MirrorWindow: NSPanel {
     }
 
     private func windowFrame(for size: NSSize) -> NSRect {
-        let screen = NSScreen.main ?? NSScreen.screens.first
-        guard let screen else {
+        // Place Mirror on the screen with the active window, not always the main display.
+        guard let screen = NSScreen.active else {
             return NSRect(origin: .zero, size: size)
         }
 


### PR DESCRIPTION
Place Trace UI on the display that contains the focused window of the last-active app, instead of always using the main display or cursor position. 