### PR TITLE
Use sidebar layout for settings

### DIFF
--- a/trace.xcodeproj/project.pbxproj
+++ b/trace.xcodeproj/project.pbxproj
@@ -299,7 +299,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = Trace;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = trace/trace.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -332,7 +331,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = Trace;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = trace/trace.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/trace/Core/AppDelegate.swift
+++ b/trace/Core/AppDelegate.swift
@@ -123,6 +123,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupMenuBar() {
         guard settingsManager.settings.showMenuBarIcon else { return }
 
+        createMenuBarStatusItem()
+    }
+
+    private func createMenuBarStatusItem() {
         if let statusItem {
             NSStatusBar.system.removeStatusItem(statusItem)
             self.statusItem = nil
@@ -237,10 +241,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     @objc private func settingsChanged() {
-        // Check if menu bar preference changed
-        if settingsManager.settings.showMenuBarIcon {
+        applyMenuBarIconVisibility(settingsManager.settings.showMenuBarIcon)
+    }
+
+    private func applyMenuBarIconVisibility(_ isVisible: Bool) {
+        if isVisible {
             if statusItem == nil {
-                setupMenuBar()
+                createMenuBarStatusItem()
             } else {
                 // Refresh the menu to update hotkey display
                 updateStatusItemAppearance()
@@ -259,8 +266,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .map { $0.showMenuBarIcon }
             .removeDuplicates()
             .dropFirst()
-            .sink { [weak self] _ in
-                self?.settingsChanged()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isVisible in
+                // @Published emits from willSet, so use the emitted value instead
+                // of reading SettingsManager.settings before storage is updated.
+                self?.applyMenuBarIconVisibility(isVisible)
             }
     }
     

--- a/trace/Info.plist
+++ b/trace/Info.plist
@@ -34,8 +34,6 @@
     <string>26.0</string>
     <key>LSUIElement</key>
     <true/>
-    <key>NSAccentColorName</key>
-    <string>AccentColor</string>
     <key>NSAppleEventsUsageDescription</key>
     <string>Trace needs permission to control system settings like appearance through Apple Events.</string>
     <key>NSAccessibilityUsageDescription</key>

--- a/trace/Managers/AppSearchManager.swift
+++ b/trace/Managers/AppSearchManager.swift
@@ -12,6 +12,29 @@ import CoreServices
 import Darwin
 import Ifrit
 
+private final class AppIconCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var icons: [String: NSImage] = [:]
+
+    func icon(for bundleIdentifier: String) -> NSImage? {
+        lock.lock()
+        defer { lock.unlock() }
+        return icons[bundleIdentifier]
+    }
+
+    func insert(_ icon: NSImage, for bundleIdentifier: String) {
+        lock.lock()
+        icons[bundleIdentifier] = icon
+        lock.unlock()
+    }
+
+    func removeAll() {
+        lock.lock()
+        icons.removeAll()
+        lock.unlock()
+    }
+}
+
 class AppSearchManager: ObservableObject {
 
     private let logger = AppLogger.appSearchManager
@@ -20,8 +43,7 @@ class AppSearchManager: ObservableObject {
     private var apps: [String: Application] = [:] // bundleId -> Application
     private var appsByName: [String: Set<String>] = [:] // lowercase name -> bundle IDs
     private let iconQueue = DispatchQueue(label: "com.trace.appsearch.icons", qos: .utility)
-    private var iconCache: [String: NSImage] = [:] // bundleId -> NSImage cache
-    private let iconCacheQueue = DispatchQueue(label: "com.trace.appsearch.iconcache", attributes: .concurrent)
+    private let iconCache = AppIconCache()
     private var fileSystemEventStream: FSEventStreamRef?
     private var scheduledRefreshWorkItem: DispatchWorkItem?
     private var currentLoadTask: Task<Void, Never>?
@@ -111,36 +133,22 @@ class AppSearchManager: ObservableObject {
     func getAppIcon(for app: Application) async -> NSImage? {
         let bundleId = app.bundleIdentifier
 
-        // Check cache first (concurrent read)
-        let cachedIcon = await withCheckedContinuation { continuation in
-            iconCacheQueue.async { [weak self] in
-                let icon = self?.iconCache[bundleId]
+        if let cachedIcon = iconCache.icon(for: bundleId) {
+            return cachedIcon
+        }
+
+        let appPath = app.url.path
+        let icon = await withCheckedContinuation { continuation in
+            iconQueue.async {
+                let icon = NSWorkspace.shared.icon(forFile: appPath)
+                icon.size = AppConstants.Search.iconSize
                 continuation.resume(returning: icon)
             }
         }
 
-        if let cachedIcon = cachedIcon {
-            return cachedIcon
-        }
-
-        // Load icon asynchronously
-        return await withCheckedContinuation { continuation in
-            iconQueue.async { [weak self] in
-                let icon = NSWorkspace.shared.icon(forFile: app.url.path)
-                icon.size = AppConstants.Search.iconSize
-
-                // Store in concurrent cache
-                self?.iconCacheQueue.async(flags: .barrier) {
-                    self?.iconCache[bundleId] = icon
-                }
-
-                // Also update the app's icon property for direct access
-                Task { @MainActor in
-                    self?.apps[bundleId]?.icon = icon
-                    continuation.resume(returning: icon)
-                }
-            }
-        }
+        iconCache.insert(icon, for: bundleId)
+        apps[bundleId]?.icon = icon
+        return icon
     }
 
 
@@ -453,9 +461,7 @@ class AppSearchManager: ObservableObject {
     }
 
     private func clearIconCache() {
-        iconCacheQueue.async(flags: .barrier) { [weak self] in
-            self?.iconCache.removeAll()
-        }
+        iconCache.removeAll()
     }
 
     private func rebuildNameIndex() {

--- a/trace/Search/Providers/MenuItemProvider.swift
+++ b/trace/Search/Providers/MenuItemProvider.swift
@@ -251,7 +251,9 @@ class MenuItemProvider: ResultProvider {
     }
 }
 
-struct MenuItemCommandAction: DisplayableCommandAction {
+/// The payload is immutable, and MenuBarService protects its shared cache with a lock.
+/// App activation is explicitly marshalled onto the main queue before the AX action runs.
+struct MenuItemCommandAction: DisplayableCommandAction, @unchecked Sendable {
     let id: String
     let displayName: String
     let iconName: String?

--- a/trace/Services/CalendarManager.swift
+++ b/trace/Services/CalendarManager.swift
@@ -236,7 +236,7 @@ class CalendarManager: ObservableObject {
         
         var error: NSDictionary?
         let appleScript = NSAppleScript(source: script)
-        let result = appleScript?.executeAndReturnError(&error)
+        _ = appleScript?.executeAndReturnError(&error)
         
         if error == nil {
             logger.info("Opened calendar event using AppleScript")

--- a/trace/Services/MenuBarService.swift
+++ b/trace/Services/MenuBarService.swift
@@ -100,9 +100,9 @@ class MenuBarService {
 
     private func activate(_ app: NSRunningApplication) {
         if Thread.isMainThread {
-            app.activate()
+            _ = app.activate()
         } else {
-            DispatchQueue.main.sync {
+            _ = DispatchQueue.main.sync {
                 app.activate()
             }
         }

--- a/trace/Services/NetworkUtilities.swift
+++ b/trace/Services/NetworkUtilities.swift
@@ -3,7 +3,8 @@ import Network
 import AppKit
 import os.log
 
-class NetworkUtilities {
+/// All mutable cache state is confined to `queue`.
+final class NetworkUtilities: @unchecked Sendable {
     static let shared = NetworkUtilities()
     private let logger = AppLogger.networkUtilities
     
@@ -11,7 +12,7 @@ class NetworkUtilities {
     private var cachedPublicIP: (ip: String, timestamp: Date)?
     private var cachedPrivateIP: (ip: String, timestamp: Date)?
     private let cacheTimeout: TimeInterval = 300 // 5 minutes
-    private let queue = DispatchQueue(label: "com.trace.networkutilities", attributes: .concurrent)
+    private let queue = DispatchQueue(label: "com.trace.networkutilities")
     
     private init() {
         // NetworkUtilities initialized - public IP will be fetched only when requested
@@ -39,7 +40,7 @@ class NetworkUtilities {
     /// Get public IP address (async, always fresh)
     func getPublicIPAddress() async -> String? {
         if let ip = await fetchPublicIPAddress() {
-            queue.async(flags: .barrier) {
+            queue.async {
                 self.cachedPublicIP = (ip: ip, timestamp: Date())
             }
             return ip

--- a/trace/Services/PermissionManager.swift
+++ b/trace/Services/PermissionManager.swift
@@ -212,7 +212,7 @@ class PermissionManager: ObservableObject {
                 }
                 
                 // Restore focus to the target application after successful window operation
-                app.activate(options: [.activateIgnoringOtherApps])
+                _ = app.activate()
                 logger.debug("Restored focus to app: \(app.localizedName ?? app.bundleIdentifier ?? "Unknown")")
                 
                 // Clear lastActiveApplication to prevent double focus restoration when clicking elsewhere
@@ -360,7 +360,7 @@ class PermissionManager: ObservableObject {
         if pidResult == .success,
            let targetApp = NSRunningApplication(processIdentifier: appPid) {
             // Activate the app to restore focus after window manipulation
-            targetApp.activate(options: [.activateIgnoringOtherApps])
+            _ = targetApp.activate()
             logger.debug("Restored focus to app: \(targetApp.localizedName ?? targetApp.bundleIdentifier ?? "Unknown")")
         } else {
             logger.warning("Failed to activate app for window - could not get process ID")
@@ -398,7 +398,7 @@ class PermissionManager: ObservableObject {
         let calendarManager = CalendarManager.shared
         let granted = await calendarManager.requestAccess()
         
-        DispatchQueue.main.async {
+        await MainActor.run {
             self.calendarAvailable = granted
         }
         

--- a/trace/Services/ProcessUsageMonitor.swift
+++ b/trace/Services/ProcessUsageMonitor.swift
@@ -65,7 +65,8 @@ struct ProcessUsageSnapshot: Equatable {
     }
 }
 
-final class ProcessUsageMonitor {
+/// Mutable sampling state is confined to `queue`; synchronous reads use the same queue.
+final class ProcessUsageMonitor: @unchecked Sendable {
     private static let minimumCPUCalculationInterval: TimeInterval = 0.5
     private static let processTreeSnapshotStaleness: TimeInterval = 1.0
 

--- a/trace/Utils/MathEvaluator.swift
+++ b/trace/Utils/MathEvaluator.swift
@@ -46,11 +46,11 @@ struct MathEvaluator {
         end try
         """
         
-        let appleScript = NSAppleScript(source: script)
-        var error: NSDictionary?
-        
         return await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
+                let appleScript = NSAppleScript(source: script)
+                var error: NSDictionary?
+
                 guard let output = appleScript?.executeAndReturnError(&error),
                       error == nil,
                       let result = output.stringValue,

--- a/trace/Views/Settings/BackupSyncSettingsView.swift
+++ b/trace/Views/Settings/BackupSyncSettingsView.swift
@@ -1,0 +1,144 @@
+//
+//  BackupSyncSettingsView.swift
+//  trace
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct BackupSyncSettingsView: View {
+    @ObservedObject private var settingsManager = SettingsManager.shared
+    @State private var showingExportSuccessAlert = false
+    @State private var showingImportAlert = false
+    @State private var showingImportFileImporter = false
+    @State private var exportedFileURL: URL?
+    @State private var importOverwriteExisting = false
+
+    var body: some View {
+        NativeSettingsPane {
+            NativeSettingsSection("Settings Backup") {
+                NativeSettingsRow(
+                    title: "Export Settings",
+                    subtitle: "Save all your Trace settings to a file"
+                ) {
+                    Button("Export...") {
+                        exportSettings()
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                NativeSettingsDivider()
+
+                NativeSettingsRow(
+                    title: "Import Settings",
+                    subtitle: "Restore settings from a previously exported file"
+                ) {
+                    Button("Import...") {
+                        showingImportAlert = true
+                    }
+                    .buttonStyle(.bordered)
+                }
+            } footer: {
+                Text("Export includes hotkeys, custom folders, app preferences, and usage statistics.")
+            }
+
+            RemoteSettingsSyncView()
+        }
+        .alert("Export Successful", isPresented: $showingExportSuccessAlert) {
+            Button("Open in Finder") {
+                if let url = exportedFileURL {
+                    NSWorkspace.shared.selectFile(url.path, inFileViewerRootedAtPath: "")
+                }
+            }
+            Button("OK") { }
+        } message: {
+            if let url = exportedFileURL {
+                Text("Settings exported to:\n\(url.lastPathComponent)")
+            }
+        }
+        .alert("Import Settings", isPresented: $showingImportAlert) {
+            Button("Replace All Settings") {
+                importOverwriteExisting = true
+                showingImportFileImporter = true
+            }
+            Button("Keep Existing (Add Missing)") {
+                importOverwriteExisting = false
+                showingImportFileImporter = true
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Choose how to handle existing settings when importing.")
+        }
+        .fileImporter(
+            isPresented: $showingImportFileImporter,
+            allowedContentTypes: [UTType.json],
+            allowsMultipleSelection: false,
+            onCompletion: handleImportFileSelection
+        )
+    }
+
+    private func exportSettings() {
+        do {
+            exportedFileURL = try settingsManager.exportToFile()
+            showingExportSuccessAlert = true
+        } catch {
+            showAlert(title: "Export Failed", message: error.localizedDescription)
+        }
+    }
+
+    private func handleImportFileSelection(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            importSettings(from: url)
+        case .failure(let error):
+            showAlert(title: "File Selection Failed", message: error.localizedDescription)
+        }
+    }
+
+    private func importSettings(from url: URL) {
+        do {
+            try settingsManager.importFromFile(url, overwriteExisting: importOverwriteExisting)
+            reloadManagersAfterImport()
+            showAlert(
+                title: "Import Successful",
+                message: "Settings have been imported and all managers have been reloaded. All imported hotkeys should now work immediately."
+            )
+        } catch {
+            showAlert(title: "Import Failed", message: error.localizedDescription)
+        }
+    }
+
+    private func reloadManagersAfterImport() {
+        AppHotkeyManager.shared.setupHotkeys()
+
+        let windowHotkeyManager = WindowHotkeyManager.shared
+        for (position, hotkeyData) in settingsManager.settings.windowHotkeys {
+            if let windowPosition = WindowPosition(rawValue: position) {
+                windowHotkeyManager.updateHotkey(
+                    for: windowPosition,
+                    keyCombo: hotkeyData.hotkey,
+                    keyCode: UInt32(hotkeyData.keyCode),
+                    modifiers: UInt32(hotkeyData.modifiers)
+                )
+            }
+        }
+
+        DispatchQueue.main.async {
+            ServiceContainer.shared.quickLinksManager.loadQuickLinks()
+        }
+
+        DictationHotkeyManager.shared.reload()
+    }
+
+    private func showAlert(title: String, message: String) {
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = title
+            alert.informativeText = message
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+        }
+    }
+}

--- a/trace/Views/Settings/DictationSettingsView.swift
+++ b/trace/Views/Settings/DictationSettingsView.swift
@@ -1,22 +1,14 @@
 import AppKit
-import AVFoundation
 import Carbon
-import Speech
 import SwiftUI
 
 struct DictationSettingsView: View {
     @ObservedObject private var settingsManager = SettingsManager.shared
     @ObservedObject private var assetManager = DictationAssetManager.shared
-    @ObservedObject private var permissionManager = PermissionManager.shared
     @Environment(\.traceTheme) private var traceTheme
 
     @State private var isRecordingHotkey = false
     @State private var eventMonitor: Any?
-    @State private var requestingMicrophone = false
-    @State private var requestingSpeechRecognition = false
-    @State private var microphoneAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
-    @State private var speechRecognitionAuthorizationStatus = SFSpeechRecognizer.authorizationStatus()
-    @State private var accessibilityTrusted = AXIsProcessTrusted()
 
     var body: some View {
         NativeSettingsPane {
@@ -108,44 +100,12 @@ struct DictationSettingsView: View {
                 Text("Speech assets are downloaded only when you click Download. Assets are managed by macOS and shared with system dictation.")
             }
 
-            NativeSettingsSection("Permissions") {
-                PermissionRow(
-                    title: "Microphone Access",
-                    subtitle: "Required to capture your speech while the hotkey is held",
-                    icon: "mic",
-                    status: microphonePermissionStatus,
-                    action: handleMicrophonePermission,
-                    buttonTitle: microphoneButtonTitle
-                )
-
-                NativeSettingsDivider()
-
-                PermissionRow(
-                    title: "Speech Recognition",
-                    subtitle: "Required to transcribe audio on this Mac",
-                    icon: "waveform",
-                    status: speechRecognitionPermissionStatus,
-                    action: handleSpeechRecognitionPermission,
-                    buttonTitle: speechRecognitionButtonTitle
-                )
-
-                NativeSettingsDivider()
-
-                PermissionRow(
-                    title: "Accessibility Access",
-                    subtitle: "Required to paste dictated text into the active app",
-                    icon: "accessibility",
-                    status: accessibilityTrusted ? .granted : .denied,
-                    action: openAccessibilitySettings
-                )
-            }
         }
         .onAppear {
-            refreshPermissions()
             Task { await assetManager.refresh() }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            refreshPermissions()
+            Task { await assetManager.refresh() }
         }
         .onDisappear {
             stopRecordingHotkey()
@@ -222,83 +182,6 @@ struct DictationSettingsView: View {
     private var assetButtonTitle: String {
         if case .failed = assetManager.state { return "Retry" }
         return "Download"
-    }
-
-    private var microphonePermissionStatus: PermissionStatus {
-        if requestingMicrophone { return .checking }
-        switch microphoneAuthorizationStatus {
-        case .authorized: return .granted
-        case .notDetermined: return .notDetermined
-        case .denied, .restricted: return .denied
-        @unknown default: return .denied
-        }
-    }
-
-    private var speechRecognitionPermissionStatus: PermissionStatus {
-        if requestingSpeechRecognition { return .checking }
-        switch speechRecognitionAuthorizationStatus {
-        case .authorized: return .granted
-        case .notDetermined: return .notDetermined
-        case .denied, .restricted: return .denied
-        @unknown default: return .denied
-        }
-    }
-
-    private var microphoneButtonTitle: String {
-        microphoneAuthorizationStatus == .notDetermined ? "Request Permission" : "Open Settings"
-    }
-
-    private var speechRecognitionButtonTitle: String {
-        speechRecognitionAuthorizationStatus == .notDetermined ? "Request Permission" : "Open Settings"
-    }
-
-    private func handleMicrophonePermission() {
-        refreshPermissions()
-
-        if microphoneAuthorizationStatus == .notDetermined {
-            Task {
-                requestingMicrophone = true
-                _ = await permissionManager.requestMicrophonePermission()
-                refreshPermissions()
-                requestingMicrophone = false
-            }
-        } else {
-            permissionManager.openMicrophonePrivacySettings()
-        }
-    }
-
-    private func handleSpeechRecognitionPermission() {
-        refreshPermissions()
-
-        if speechRecognitionAuthorizationStatus == .notDetermined {
-            Task {
-                requestingSpeechRecognition = true
-                let granted = await permissionManager.requestSpeechRecognitionPermission()
-                refreshPermissions()
-                if granted {
-                    await assetManager.refresh()
-                }
-                requestingSpeechRecognition = false
-            }
-        } else {
-            permissionManager.openSpeechRecognitionPrivacySettings()
-        }
-    }
-
-    private func openAccessibilitySettings() {
-        refreshPermissions()
-
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
-    private func refreshPermissions() {
-        permissionManager.refreshMicrophoneCapability()
-        permissionManager.refreshSpeechRecognitionCapability()
-        microphoneAuthorizationStatus = permissionManager.microphoneAuthorizationStatus
-        speechRecognitionAuthorizationStatus = permissionManager.speechRecognitionAuthorizationStatus
-        accessibilityTrusted = AXIsProcessTrusted()
     }
 
     private func startRecordingHotkey() {

--- a/trace/Views/Settings/DictationSettingsView.swift
+++ b/trace/Views/Settings/DictationSettingsView.swift
@@ -1,14 +1,22 @@
 import AppKit
+import AVFoundation
 import Carbon
+import Speech
 import SwiftUI
 
 struct DictationSettingsView: View {
     @ObservedObject private var settingsManager = SettingsManager.shared
     @ObservedObject private var assetManager = DictationAssetManager.shared
+    @ObservedObject private var permissionManager = PermissionManager.shared
     @Environment(\.traceTheme) private var traceTheme
 
     @State private var isRecordingHotkey = false
     @State private var eventMonitor: Any?
+    @State private var requestingMicrophone = false
+    @State private var requestingSpeechRecognition = false
+    @State private var microphoneAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+    @State private var speechRecognitionAuthorizationStatus = SFSpeechRecognizer.authorizationStatus()
+    @State private var accessibilityTrusted = AXIsProcessTrusted()
 
     var body: some View {
         NativeSettingsPane {
@@ -100,11 +108,47 @@ struct DictationSettingsView: View {
                 Text("Speech assets are downloaded only when you click Download. Assets are managed by macOS and shared with system dictation.")
             }
 
+            NativeSettingsSection("Permissions") {
+                PermissionRow(
+                    title: "Microphone",
+                    subtitle: "Captures audio only while you hold the push-to-talk hotkey. Trace does not save the audio.",
+                    icon: "mic",
+                    status: microphonePermissionStatus,
+                    action: handleMicrophonePermission,
+                    buttonTitle: microphonePermissionButtonTitle
+                )
+
+                NativeSettingsDivider()
+
+                PermissionRow(
+                    title: "Speech Recognition",
+                    subtitle: "Uses Apple’s on-device speech recognition and downloaded language assets to turn dictation into text. Trace does not store transcripts.",
+                    icon: "waveform",
+                    status: speechRecognitionPermissionStatus,
+                    action: handleSpeechRecognitionPermission,
+                    buttonTitle: speechRecognitionPermissionButtonTitle
+                )
+
+                NativeSettingsDivider()
+
+                PermissionRow(
+                    title: "Accessibility",
+                    subtitle: "Lets Trace paste dictated text into the active app.",
+                    icon: "accessibility",
+                    status: accessibilityTrusted ? .granted : .denied,
+                    action: openAccessibilitySettings,
+                    buttonTitle: "Open Settings"
+                )
+            } footer: {
+                Text("These controls are also available in the Permissions tab for easy access.")
+            }
         }
         .onAppear {
+            refreshPermissions()
             Task { await assetManager.refresh() }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshPermissions()
             Task { await assetManager.refresh() }
         }
         .onDisappear {
@@ -182,6 +226,92 @@ struct DictationSettingsView: View {
     private var assetButtonTitle: String {
         if case .failed = assetManager.state { return "Retry" }
         return "Download"
+    }
+
+    private var microphonePermissionStatus: PermissionStatus {
+        if requestingMicrophone { return .checking }
+        switch microphoneAuthorizationStatus {
+        case .authorized:
+            return .granted
+        case .notDetermined:
+            return .notDetermined
+        case .denied, .restricted:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
+    private var speechRecognitionPermissionStatus: PermissionStatus {
+        if requestingSpeechRecognition { return .checking }
+        switch speechRecognitionAuthorizationStatus {
+        case .authorized:
+            return .granted
+        case .notDetermined:
+            return .notDetermined
+        case .denied, .restricted:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
+    private var microphonePermissionButtonTitle: String {
+        microphoneAuthorizationStatus == .notDetermined ? "Request Permission" : "Open Settings"
+    }
+
+    private var speechRecognitionPermissionButtonTitle: String {
+        speechRecognitionAuthorizationStatus == .notDetermined ? "Request Permission" : "Open Settings"
+    }
+
+    private func handleMicrophonePermission() {
+        refreshPermissions()
+        guard microphoneAuthorizationStatus == .notDetermined else {
+            permissionManager.openMicrophonePrivacySettings()
+            return
+        }
+
+        Task {
+            requestingMicrophone = true
+            _ = await permissionManager.requestMicrophonePermission()
+            requestingMicrophone = false
+            refreshPermissions()
+        }
+    }
+
+    private func handleSpeechRecognitionPermission() {
+        refreshPermissions()
+        guard speechRecognitionAuthorizationStatus == .notDetermined else {
+            permissionManager.openSpeechRecognitionPrivacySettings()
+            return
+        }
+
+        Task {
+            requestingSpeechRecognition = true
+            let granted = await permissionManager.requestSpeechRecognitionPermission()
+            requestingSpeechRecognition = false
+            refreshPermissions()
+            if granted {
+                await assetManager.refresh()
+            }
+        }
+    }
+
+    private func openAccessibilitySettings() {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        ) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func refreshPermissions() {
+        permissionManager.refreshMicrophoneCapability()
+        permissionManager.refreshSpeechRecognitionCapability()
+        microphoneAuthorizationStatus = permissionManager.microphoneAuthorizationStatus
+        speechRecognitionAuthorizationStatus = permissionManager.speechRecognitionAuthorizationStatus
+        accessibilityTrusted = AXIsProcessTrusted()
     }
 
     private func startRecordingHotkey() {

--- a/trace/Views/Settings/GeneralSettingsView.swift
+++ b/trace/Views/Settings/GeneralSettingsView.swift
@@ -22,11 +22,8 @@ struct GeneralSettingsView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.traceTheme) private var traceTheme
     
-    // Permissions states
     @ObservedObject private var permissionManager = PermissionManager.shared
-    @State private var accessibilityEnabled = false
     @State private var calendarEnabled = false
-    @State private var checkingPermissions = false
     @State private var requestingCalendarPermission = false
     let onLaunchAtLoginChange: (Bool) -> Void
     let onHotkeyRecord: (UInt32, UInt32) -> Void
@@ -92,61 +89,6 @@ struct GeneralSettingsView: View {
                             onLaunchAtLoginChange(newValue)
                         }
                 }
-            }
-
-            NativeSettingsSection("Permissions") {
-                PermissionRow(
-                    title: "Accessibility Access",
-                    subtitle: "Enables window management and global hotkeys",
-                    icon: "accessibility",
-                    status: accessibilityEnabled ? .granted : .denied,
-                    action: {
-                        openAccessibilitySettings()
-                    }
-                )
-
-                NativeSettingsDivider()
-
-                PermissionRow(
-                    title: "Calendar Access",
-                    subtitle: "Enables calendar event search",
-                    icon: "calendar",
-                    status: requestingCalendarPermission || checkingPermissions ? .checking : (calendarEnabled ? .granted : .denied),
-                    action: {
-                        if calendarEnabled {
-                            openCalendarPrivacySettings()
-                        } else {
-                            requestCalendarPermission()
-                        }
-                    },
-                    buttonTitle: calendarEnabled ? "Open Settings" : "Request Permission"
-                )
-
-                NativeSettingsDivider()
-                
-                HStack {
-                    Text("Permission status is checked automatically when this tab opens.")
-                        .font(.system(size: 11))
-                        .foregroundColor(.secondary)
-                    
-                    Spacer()
-                    
-                    Button(action: checkPermissions) {
-                        HStack(spacing: 4) {
-                            Image(systemName: checkingPermissions ? "arrow.clockwise" : "arrow.clockwise")
-                                .font(.system(size: 11))
-                            Text("Refresh")
-                                .font(.system(size: 11))
-                        }
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(checkingPermissions)
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 7)
-                .frame(minHeight: 44)
-            } footer: {
-                Text("All permissions are optional. Features that need a permission may be unavailable until you grant it, and you can change access any time in System Settings.")
             }
 
             NativeSettingsSection("Interface") {
@@ -269,8 +211,10 @@ struct GeneralSettingsView: View {
             showMenuBarIcon = settingsManager.settings.showMenuBarIcon
             accentColor = settingsManager.selectedAccent
             
-            // Check permissions
-            checkPermissions()
+            calendarEnabled = permissionManager.testCalendarCapability()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            calendarEnabled = permissionManager.testCalendarCapability()
         }
         .onDisappear {
             stopRecording()
@@ -357,53 +301,6 @@ struct GeneralSettingsView: View {
         }
     }
     
-    // MARK: - Permissions Methods
-    
-    private func checkPermissions() {
-        guard !checkingPermissions else { return } // Prevent concurrent checks
-        checkingPermissions = true
-        
-        // Check accessibility permissions with retry mechanism for release builds
-        checkAccessibilityPermissions()
-        
-        // Check calendar permissions
-        checkCalendarPermissions()
-    }
-    
-    private func checkAccessibilityPermissions() {
-        DispatchQueue.global(qos: .userInitiated).async {
-            let capability = self.permissionManager.testWindowManagementCapability()
-            
-            DispatchQueue.main.async {
-                switch capability {
-                case .available:
-                    self.accessibilityEnabled = true
-                    
-                case .permissionDenied:
-                    self.accessibilityEnabled = false
-                    
-                case .noTargetApp, .noWindows:
-                    // These states don't indicate permission problems - use system API as fallback
-                    self.accessibilityEnabled = AXIsProcessTrusted()
-                }
-                
-                self.checkingPermissions = false // Reset the concurrent check guard
-            }
-        }
-    }
-    
-    /// Checks calendar permissions in the background and updates UI state
-    private func checkCalendarPermissions() {
-        DispatchQueue.global(qos: .userInitiated).async {
-            let hasCalendarAccess = self.permissionManager.testCalendarCapability()
-            
-            DispatchQueue.main.async {
-                self.calendarEnabled = hasCalendarAccess
-                self.checkingPermissions = false
-            }
-        }
-    }
-
     /// Requests calendar permissions from the user and enables calendar search if granted
     private func requestCalendarPermission() {
         guard !requestingCalendarPermission else { return }
@@ -426,109 +323,4 @@ struct GeneralSettingsView: View {
         }
     }
     
-    private func openAccessibilitySettings() {
-        // Open System Settings to Accessibility
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
-            NSWorkspace.shared.open(url)
-        }
-    }
-    
-    /// Opens System Settings to the Calendar privacy section
-    private func openCalendarPrivacySettings() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars") {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
-}
-
-// MARK: - Permission Types
-
-enum PermissionStatus {
-    case granted
-    case denied
-    case notDetermined
-    case checking
-    
-    var color: Color {
-        switch self {
-        case .granted: return .green
-        case .denied: return .orange
-        case .notDetermined: return .secondary
-        case .checking: return .secondary
-        }
-    }
-    
-    var icon: String {
-        switch self {
-        case .granted: return "checkmark.circle.fill"
-        case .denied: return "exclamationmark.triangle.fill"
-        case .notDetermined: return "questionmark.circle.fill"
-        case .checking: return "clock"
-        }
-    }
-    
-    var statusText: String {
-        switch self {
-        case .granted: return "Granted"
-        case .denied: return "Not Granted"
-        case .notDetermined: return "Not Requested"
-        case .checking: return "Checking..."
-        }
-    }
-}
-
-struct PermissionRow: View {
-    let title: String
-    let subtitle: String
-    let icon: String
-    let status: PermissionStatus
-    let action: () -> Void
-    let buttonTitle: String?
-    
-    var body: some View {
-        HStack(alignment: .center, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.system(size: 13))
-                Text(subtitle)
-                    .font(.system(size: 11))
-                    .foregroundColor(.secondary)
-            }
-            
-            Spacer()
-            
-            VStack(alignment: .trailing, spacing: 4) {
-                HStack(spacing: 4) {
-                    Image(systemName: status.icon)
-                        .font(.system(size: 12))
-                        .foregroundColor(status.color)
-                    
-                    Text(status.statusText)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(status.color)
-                }
-                
-                if status != .granted {
-                    Button(buttonTitle ?? "Open Settings") {
-                        action()
-                    }
-                    .font(.system(size: 11))
-                    .buttonStyle(.link)
-                }
-            }
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .frame(minHeight: 54)
-    }
-    
-    init(title: String, subtitle: String, icon: String, status: PermissionStatus, action: @escaping () -> Void, buttonTitle: String? = nil) {
-        self.title = title
-        self.subtitle = subtitle
-        self.icon = icon
-        self.status = status
-        self.action = action
-        self.buttonTitle = buttonTitle
-    }
 }

--- a/trace/Views/Settings/GeneralSettingsView.swift
+++ b/trace/Views/Settings/GeneralSettingsView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import AVFoundation
 import Carbon
 import UniformTypeIdentifiers
 import os.log
@@ -36,11 +35,8 @@ struct GeneralSettingsView: View {
     @ObservedObject private var permissionManager = PermissionManager.shared
     @State private var accessibilityEnabled = false
     @State private var calendarEnabled = false
-    @State private var cameraAuthorizationStatus: AVAuthorizationStatus = .notDetermined
     @State private var checkingPermissions = false
     @State private var requestingCalendarPermission = false
-    @State private var requestingCameraPermission = false
-    @State private var availableMirrorCameras: [AVCaptureDevice] = []
     let onLaunchAtLoginChange: (Bool) -> Void
     let onHotkeyRecord: (UInt32, UInt32) -> Void
     let onHotkeyReset: () -> Void
@@ -117,7 +113,9 @@ struct GeneralSettingsView: View {
                         openAccessibilitySettings()
                     }
                 )
-                
+
+                NativeSettingsDivider()
+
                 PermissionRow(
                     title: "Calendar Access",
                     subtitle: "Enables calendar event search",
@@ -133,23 +131,6 @@ struct GeneralSettingsView: View {
                     buttonTitle: calendarEnabled ? "Open Settings" : "Request Permission"
                 )
 
-                NativeSettingsDivider()
-
-                PermissionRow(
-                    title: "Camera Access",
-                    subtitle: "Enables the local Mirror preview",
-                    icon: "video",
-                    status: requestingCameraPermission || checkingPermissions ? .checking : cameraPermissionStatus,
-                    action: {
-                        if cameraAuthorizationStatus == .notDetermined {
-                            requestCameraPermission()
-                        } else {
-                            openCameraPrivacySettings()
-                        }
-                    },
-                    buttonTitle: cameraPermissionButtonTitle
-                )
-                
                 NativeSettingsDivider()
                 
                 HStack {
@@ -175,37 +156,6 @@ struct GeneralSettingsView: View {
                 .frame(minHeight: 44)
             } footer: {
                 Text("All permissions are optional. Features that need a permission may be unavailable until you grant it, and you can change access any time in System Settings.")
-            }
-
-            NativeSettingsSection("Mirror") {
-                NativeSettingsRow(
-                    title: "Camera",
-                    subtitle: mirrorCameraSubtitle
-                ) {
-                    Picker("", selection: Binding(
-                        get: { settingsManager.settings.mirrorCameraDeviceID },
-                        set: { settingsManager.updateMirrorCameraDeviceID($0) }
-                    )) {
-                        Text("System Default").tag("")
-
-                        ForEach(availableMirrorCameras, id: \.uniqueID) { device in
-                            Text(MirrorManager.displayName(for: device)).tag(device.uniqueID)
-                        }
-
-                        // Keep a previously saved camera visible if it is currently disconnected.
-                        if !settingsManager.settings.mirrorCameraDeviceID.isEmpty,
-                           !availableMirrorCameras.contains(where: {
-                               $0.uniqueID == settingsManager.settings.mirrorCameraDeviceID
-                           }) {
-                            Text("Unavailable camera").tag(settingsManager.settings.mirrorCameraDeviceID)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .frame(minWidth: 200, maxWidth: 260)
-                    .disabled(cameraAuthorizationStatus != .authorized)
-                }
-            } footer: {
-                Text("Choose which camera Mirror uses. System Default follows the camera recommended by macOS. Continuity Camera (iPhone/iPad) appears when the device is nearby, unlocked, and camera access is granted.")
             }
 
             NativeSettingsSection("Interface") {
@@ -354,21 +304,9 @@ struct GeneralSettingsView: View {
             resultsLayout = ResultsLayout(rawValue: settingsManager.settings.resultsLayout) ?? .compact
             showMenuBarIcon = settingsManager.settings.showMenuBarIcon
             accentColor = settingsManager.selectedAccent
-            refreshAvailableMirrorCameras()
             
             // Check permissions
             checkPermissions()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: AVCaptureDevice.wasConnectedNotification)) { _ in
-            refreshAvailableMirrorCameras()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: AVCaptureDevice.wasDisconnectedNotification)) { _ in
-            refreshAvailableMirrorCameras()
-        }
-        .onChange(of: settingsManager.settings.mirrorCameraDeviceID) { _, _ in
-            Task { @MainActor in
-                ServiceContainer.shared.mirrorManager.applyCameraSelectionChange()
-            }
         }
         .onDisappear {
             stopRecording()
@@ -571,9 +509,6 @@ struct GeneralSettingsView: View {
         
         // Check calendar permissions
         checkCalendarPermissions()
-
-        // Check camera permissions
-        checkCameraPermissions()
     }
     
     private func checkAccessibilityPermissions() {
@@ -610,64 +545,6 @@ struct GeneralSettingsView: View {
         }
     }
 
-    private var cameraPermissionStatus: PermissionStatus {
-        switch cameraAuthorizationStatus {
-        case .authorized:
-            return .granted
-        case .notDetermined:
-            return .notDetermined
-        case .denied, .restricted:
-            return .denied
-        @unknown default:
-            return .denied
-        }
-    }
-
-    private var cameraPermissionButtonTitle: String {
-        cameraAuthorizationStatus == .notDetermined ? "Request Permission" : "Open Settings"
-    }
-
-    private var mirrorCameraSubtitle: String {
-        if cameraAuthorizationStatus != .authorized {
-            return "Grant camera access to choose a Mirror camera"
-        }
-        if availableMirrorCameras.isEmpty {
-            return "No cameras detected"
-        }
-        let cameraCount = availableMirrorCameras.count
-        let cameraLabel = cameraCount == 1 ? "camera" : "cameras"
-        let continuityCount = availableMirrorCameras.filter {
-            $0.isContinuityCamera || $0.deviceType == .continuityCamera
-        }.count
-        if continuityCount > 0 {
-            return "\(cameraCount) \(cameraLabel) · includes Continuity Camera"
-        }
-        return "\(cameraCount) \(cameraLabel) available for Mirror"
-    }
-
-    private func checkCameraPermissions() {
-        cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
-        refreshAvailableMirrorCameras()
-    }
-
-    private func refreshAvailableMirrorCameras() {
-        availableMirrorCameras = MirrorManager.availableCameras()
-    }
-
-    private func requestCameraPermission() {
-        guard !requestingCameraPermission else { return }
-
-        Task {
-            requestingCameraPermission = true
-            let granted = await AVCaptureDevice.requestAccess(for: .video)
-            await MainActor.run {
-                cameraAuthorizationStatus = granted ? .authorized : AVCaptureDevice.authorizationStatus(for: .video)
-                requestingCameraPermission = false
-                refreshAvailableMirrorCameras()
-            }
-        }
-    }
-    
     /// Requests calendar permissions from the user and enables calendar search if granted
     private func requestCalendarPermission() {
         guard !requestingCalendarPermission else { return }
@@ -704,11 +581,6 @@ struct GeneralSettingsView: View {
         }
     }
 
-    private func openCameraPrivacySettings() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera") {
-            NSWorkspace.shared.open(url)
-        }
-    }
 }
 
 // MARK: - Permission Types

--- a/trace/Views/Settings/GeneralSettingsView.swift
+++ b/trace/Views/Settings/GeneralSettingsView.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 import Carbon
-import UniformTypeIdentifiers
-import os.log
 
 struct GeneralSettingsView: View {
     @Binding var launchAtLogin: Bool
@@ -20,13 +18,6 @@ struct GeneralSettingsView: View {
     @State private var hoveredAccent: TraceAccent?
     @State private var eventMonitor: Any?
     @State private var showingRestartAlert = false
-    @State private var showingExportSuccessAlert = false
-    @State private var showingImportAlert = false
-    @State private var showingImportFileImporter = false
-    @State private var showingExportFileExporter = false
-    @State private var exportedFileURL: URL?
-    @State private var importOverwriteExisting = false
-    @State private var importError: String?
     @ObservedObject private var settingsManager = SettingsManager.shared
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.traceTheme) private var traceTheme
@@ -271,33 +262,6 @@ struct GeneralSettingsView: View {
                 Text("Choose which result types appear in Trace search. Calendar search is opt-in and requires permission.")
             }
             
-            NativeSettingsSection("Settings Backup") {
-                NativeSettingsRow(
-                    title: "Export Settings",
-                    subtitle: "Save all your Trace settings to a file"
-                ) {
-                    Button("Export...") {
-                        exportSettings()
-                    }
-                    .buttonStyle(.bordered)
-                }
-                
-                NativeSettingsDivider()
-                
-                NativeSettingsRow(
-                    title: "Import Settings",
-                    subtitle: "Restore settings from a previously exported file"
-                ) {
-                    Button("Import...") {
-                        showingImportAlert = true
-                    }
-                    .buttonStyle(.bordered)
-                }
-            } footer: {
-                Text("Export includes hotkeys, custom folders, app preferences, and usage statistics.")
-            }
-
-            RemoteSettingsSyncView()
         }
         .onAppear {
             // Load settings from SettingsManager
@@ -318,111 +282,6 @@ struct GeneralSettingsView: View {
             Button("Later", role: .cancel) { }
         } message: {
             Text("The global hotkey change requires restarting Trace to take effect.")
-        }
-        .alert("Export Successful", isPresented: $showingExportSuccessAlert) {
-            Button("Open in Finder") {
-                if let url = exportedFileURL {
-                    NSWorkspace.shared.selectFile(url.path, inFileViewerRootedAtPath: "")
-                }
-            }
-            Button("OK") { }
-        } message: {
-            if let url = exportedFileURL {
-                Text("Settings exported to:\n\(url.lastPathComponent)")
-            }
-        }
-        .alert("Import Settings", isPresented: $showingImportAlert) {
-            Button("Replace All Settings") {
-                importOverwriteExisting = true
-                showingImportFileImporter = true
-            }
-            Button("Keep Existing (Add Missing)") {
-                importOverwriteExisting = false
-                showingImportFileImporter = true
-            }
-            Button("Cancel", role: .cancel) { }
-        } message: {
-            Text("Choose how to handle existing settings when importing.")
-        }
-        .fileImporter(
-            isPresented: $showingImportFileImporter,
-            allowedContentTypes: [UTType.json],
-            allowsMultipleSelection: false
-        ) { result in
-            handleImportFileSelection(result)
-        }
-    }
-    
-    // MARK: - Settings Import/Export
-    
-    private func exportSettings() {
-        do {
-            let fileURL = try settingsManager.exportToFile()
-            exportedFileURL = fileURL
-            showingExportSuccessAlert = true
-        } catch {
-            showAlert(title: "Export Failed", message: error.localizedDescription)
-        }
-    }
-    
-    private func handleImportFileSelection(_ result: Result<[URL], Error>) {
-        switch result {
-        case .success(let urls):
-            guard let url = urls.first else { return }
-            importSettings(from: url)
-        case .failure(let error):
-            showAlert(title: "File Selection Failed", message: error.localizedDescription)
-        }
-    }
-    
-    private func importSettings(from url: URL) {
-        do {
-            try settingsManager.importFromFile(url, overwriteExisting: importOverwriteExisting)
-            
-            // Reload all managers after import
-            reloadManagersAfterImport()
-            
-            showAlert(title: "Import Successful", 
-                     message: "Settings have been imported and all managers have been reloaded. All imported hotkeys should now work immediately.")
-        } catch {
-            showAlert(title: "Import Failed", message: error.localizedDescription)
-        }
-    }
-    
-    private func reloadManagersAfterImport() {
-        // Reload app hotkeys
-        AppHotkeyManager.shared.setupHotkeys()
-        
-        // Reload window hotkeys
-        let windowHotkeyManager = WindowHotkeyManager.shared
-        for (position, hotkeyData) in settingsManager.settings.windowHotkeys {
-            if let windowPosition = WindowPosition(rawValue: position) {
-                windowHotkeyManager.updateHotkey(
-                    for: windowPosition,
-                    keyCombo: hotkeyData.hotkey,
-                    keyCode: UInt32(hotkeyData.keyCode),
-                    modifiers: UInt32(hotkeyData.modifiers)
-                )
-            }
-        }
-        
-        // Reload quick links manager
-        DispatchQueue.main.async {
-            let serviceContainer = ServiceContainer.shared
-            serviceContainer.quickLinksManager.loadQuickLinks()
-        }
-
-        DictationHotkeyManager.shared.reload()
-    }
-    
-    private func showAlert(title: String, message: String) {
-        DispatchQueue.main.async {
-            let alert = NSAlert()
-            alert.messageText = title
-            alert.informativeText = message
-            alert.alertStyle = .informational
-            alert.addButton(withTitle: "OK")
-            alert.runModal()
         }
     }
     

--- a/trace/Views/Settings/GeneralSettingsView.swift
+++ b/trace/Views/Settings/GeneralSettingsView.swift
@@ -91,7 +91,7 @@ struct GeneralSettingsView: View {
                 }
             }
 
-            NativeSettingsSection("Interface") {
+            NativeSettingsSection("Appearance") {
                 NativeSettingsRow(
                     title: "Accent Color",
                     subtitle: "Tint Trace foregrounds and Liquid Glass surfaces",
@@ -161,9 +161,9 @@ struct GeneralSettingsView: View {
                             settingsManager.updateShowMenuBarIcon(newValue)
                         }
                 }
-            }
 
-            NativeSettingsSection("Search Results") {
+                NativeSettingsDivider()
+
                 NativeSettingsRow(
                     title: "Results Layout",
                     subtitle: "Choose how search results are displayed"
@@ -179,9 +179,13 @@ struct GeneralSettingsView: View {
                         settingsManager.updateResultsLayout(newValue.rawValue)
                     }
                 }
+            }
 
+            NativeSettingsSection("Search Results") {
                 ForEach(SearchResultSource.allCases) { source in
-                    NativeSettingsDivider()
+                    if source != .applications {
+                        NativeSettingsDivider()
+                    }
 
                     NativeSettingsRow(
                         title: source.displayName,

--- a/trace/Views/Settings/MirrorSettingsView.swift
+++ b/trace/Views/Settings/MirrorSettingsView.swift
@@ -1,0 +1,159 @@
+//
+//  MirrorSettingsView.swift
+//  trace
+//
+
+import AVFoundation
+import SwiftUI
+
+struct MirrorSettingsView: View {
+    @ObservedObject private var settingsManager = SettingsManager.shared
+    @State private var cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+    @State private var requestingCameraPermission = false
+    @State private var availableCameras: [AVCaptureDevice] = []
+
+    var body: some View {
+        NativeSettingsPane {
+            NativeSettingsSection("Permission") {
+                PermissionRow(
+                    title: "Camera Access",
+                    subtitle: "Enables the local Mirror preview",
+                    icon: "video",
+                    status: requestingCameraPermission ? .checking : cameraPermissionStatus,
+                    action: handleCameraPermissionAction,
+                    buttonTitle: cameraPermissionButtonTitle
+                )
+            } footer: {
+                Text("Camera access is only used for the local Mirror preview. You can change access any time in System Settings.")
+            }
+
+            NativeSettingsSection("Camera") {
+                NativeSettingsRow(
+                    title: "Camera",
+                    subtitle: cameraSubtitle
+                ) {
+                    Picker("", selection: selectedCameraID) {
+                        Text("System Default").tag("")
+
+                        ForEach(availableCameras, id: \.uniqueID) { device in
+                            Text(MirrorManager.displayName(for: device)).tag(device.uniqueID)
+                        }
+
+                        if !settingsManager.settings.mirrorCameraDeviceID.isEmpty,
+                           !availableCameras.contains(where: {
+                               $0.uniqueID == settingsManager.settings.mirrorCameraDeviceID
+                           }) {
+                            Text("Unavailable camera").tag(settingsManager.settings.mirrorCameraDeviceID)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(minWidth: 200, maxWidth: 260)
+                    .disabled(cameraAuthorizationStatus != .authorized)
+                }
+            } footer: {
+                Text("System Default follows the camera recommended by macOS. Continuity Camera appears when your iPhone or iPad is nearby, unlocked, and camera access is granted.")
+            }
+        }
+        .onAppear(perform: refreshCameraState)
+        .onReceive(NotificationCenter.default.publisher(for: AVCaptureDevice.wasConnectedNotification)) { _ in
+            refreshAvailableCameras()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AVCaptureDevice.wasDisconnectedNotification)) { _ in
+            refreshAvailableCameras()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshCameraState()
+        }
+        .onChange(of: settingsManager.settings.mirrorCameraDeviceID) { _, _ in
+            Task { @MainActor in
+                ServiceContainer.shared.mirrorManager.applyCameraSelectionChange()
+            }
+        }
+    }
+
+    private var selectedCameraID: Binding<String> {
+        Binding(
+            get: { settingsManager.settings.mirrorCameraDeviceID },
+            set: { settingsManager.updateMirrorCameraDeviceID($0) }
+        )
+    }
+
+    private var cameraPermissionStatus: PermissionStatus {
+        switch cameraAuthorizationStatus {
+        case .authorized:
+            return .granted
+        case .notDetermined:
+            return .notDetermined
+        case .denied, .restricted:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
+    private var cameraPermissionButtonTitle: String {
+        cameraAuthorizationStatus == .notDetermined ? "Request Permission" : "Open Settings"
+    }
+
+    private var cameraSubtitle: String {
+        guard cameraAuthorizationStatus == .authorized else {
+            return "Grant camera access to choose a Mirror camera"
+        }
+        guard !availableCameras.isEmpty else {
+            return "No cameras detected"
+        }
+
+        let cameraCount = availableCameras.count
+        let cameraLabel = cameraCount == 1 ? "camera" : "cameras"
+        let continuityCount = availableCameras.filter {
+            $0.isContinuityCamera || $0.deviceType == .continuityCamera
+        }.count
+
+        if continuityCount > 0 {
+            return "\(cameraCount) \(cameraLabel) · includes Continuity Camera"
+        }
+        return "\(cameraCount) \(cameraLabel) available"
+    }
+
+    private func handleCameraPermissionAction() {
+        if cameraAuthorizationStatus == .notDetermined {
+            requestCameraPermission()
+        } else {
+            openCameraPrivacySettings()
+        }
+    }
+
+    private func refreshCameraState() {
+        cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        refreshAvailableCameras()
+    }
+
+    private func refreshAvailableCameras() {
+        availableCameras = MirrorManager.availableCameras()
+    }
+
+    private func requestCameraPermission() {
+        guard !requestingCameraPermission else { return }
+
+        Task {
+            requestingCameraPermission = true
+            let granted = await AVCaptureDevice.requestAccess(for: .video)
+            await MainActor.run {
+                cameraAuthorizationStatus = granted
+                    ? .authorized
+                    : AVCaptureDevice.authorizationStatus(for: .video)
+                requestingCameraPermission = false
+                refreshAvailableCameras()
+            }
+        }
+    }
+
+    private func openCameraPrivacySettings() {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+        ) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/trace/Views/Settings/MirrorSettingsView.swift
+++ b/trace/Views/Settings/MirrorSettingsView.swift
@@ -9,10 +9,24 @@ import SwiftUI
 struct MirrorSettingsView: View {
     @ObservedObject private var settingsManager = SettingsManager.shared
     @State private var cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+    @State private var requestingCameraPermission = false
     @State private var availableCameras: [AVCaptureDevice] = []
 
     var body: some View {
         NativeSettingsPane {
+            NativeSettingsSection("Permission") {
+                PermissionRow(
+                    title: "Camera",
+                    subtitle: "Used only for the live local Mirror preview. Trace does not record, save, or send camera video.",
+                    icon: "video",
+                    status: cameraPermissionStatus,
+                    action: handleCameraPermission,
+                    buttonTitle: cameraPermissionButtonTitle
+                )
+            } footer: {
+                Text("Camera access is optional and can be changed at any time in System Settings.")
+            }
+
             NativeSettingsSection("Camera") {
                 NativeSettingsRow(
                     title: "Camera",
@@ -37,7 +51,7 @@ struct MirrorSettingsView: View {
                     .disabled(cameraAuthorizationStatus != .authorized)
                 }
             } footer: {
-                Text("System Default follows the camera recommended by macOS. Continuity Camera appears when your iPhone or iPad is nearby and unlocked. Grant Camera access from the Permissions tab to choose a device.")
+                Text("System Default follows the camera recommended by macOS. Continuity Camera appears when your iPhone or iPad is nearby and unlocked.")
             }
         }
         .onAppear(perform: refreshCameraState)
@@ -62,6 +76,24 @@ struct MirrorSettingsView: View {
             get: { settingsManager.settings.mirrorCameraDeviceID },
             set: { settingsManager.updateMirrorCameraDeviceID($0) }
         )
+    }
+
+    private var cameraPermissionStatus: PermissionStatus {
+        if requestingCameraPermission { return .checking }
+        switch cameraAuthorizationStatus {
+        case .authorized:
+            return .granted
+        case .notDetermined:
+            return .notDetermined
+        case .denied, .restricted:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
+    private var cameraPermissionButtonTitle: String {
+        cameraAuthorizationStatus == .notDetermined ? "Request Permission" : "Open Settings"
     }
 
     private var cameraSubtitle: String {
@@ -91,6 +123,30 @@ struct MirrorSettingsView: View {
 
     private func refreshAvailableCameras() {
         availableCameras = MirrorManager.availableCameras()
+    }
+
+    private func handleCameraPermission() {
+        refreshCameraState()
+        guard cameraAuthorizationStatus == .notDetermined else {
+            openCameraPrivacySettings()
+            return
+        }
+
+        Task {
+            requestingCameraPermission = true
+            _ = await AVCaptureDevice.requestAccess(for: .video)
+            requestingCameraPermission = false
+            refreshCameraState()
+        }
+    }
+
+    private func openCameraPrivacySettings() {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+        ) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
     }
 
 }

--- a/trace/Views/Settings/MirrorSettingsView.swift
+++ b/trace/Views/Settings/MirrorSettingsView.swift
@@ -9,24 +9,10 @@ import SwiftUI
 struct MirrorSettingsView: View {
     @ObservedObject private var settingsManager = SettingsManager.shared
     @State private var cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
-    @State private var requestingCameraPermission = false
     @State private var availableCameras: [AVCaptureDevice] = []
 
     var body: some View {
         NativeSettingsPane {
-            NativeSettingsSection("Permission") {
-                PermissionRow(
-                    title: "Camera Access",
-                    subtitle: "Enables the local Mirror preview",
-                    icon: "video",
-                    status: requestingCameraPermission ? .checking : cameraPermissionStatus,
-                    action: handleCameraPermissionAction,
-                    buttonTitle: cameraPermissionButtonTitle
-                )
-            } footer: {
-                Text("Camera access is only used for the local Mirror preview. You can change access any time in System Settings.")
-            }
-
             NativeSettingsSection("Camera") {
                 NativeSettingsRow(
                     title: "Camera",
@@ -51,7 +37,7 @@ struct MirrorSettingsView: View {
                     .disabled(cameraAuthorizationStatus != .authorized)
                 }
             } footer: {
-                Text("System Default follows the camera recommended by macOS. Continuity Camera appears when your iPhone or iPad is nearby, unlocked, and camera access is granted.")
+                Text("System Default follows the camera recommended by macOS. Continuity Camera appears when your iPhone or iPad is nearby and unlocked. Grant Camera access from the Permissions tab to choose a device.")
             }
         }
         .onAppear(perform: refreshCameraState)
@@ -78,23 +64,6 @@ struct MirrorSettingsView: View {
         )
     }
 
-    private var cameraPermissionStatus: PermissionStatus {
-        switch cameraAuthorizationStatus {
-        case .authorized:
-            return .granted
-        case .notDetermined:
-            return .notDetermined
-        case .denied, .restricted:
-            return .denied
-        @unknown default:
-            return .denied
-        }
-    }
-
-    private var cameraPermissionButtonTitle: String {
-        cameraAuthorizationStatus == .notDetermined ? "Request Permission" : "Open Settings"
-    }
-
     private var cameraSubtitle: String {
         guard cameraAuthorizationStatus == .authorized else {
             return "Grant camera access to choose a Mirror camera"
@@ -115,14 +84,6 @@ struct MirrorSettingsView: View {
         return "\(cameraCount) \(cameraLabel) available"
     }
 
-    private func handleCameraPermissionAction() {
-        if cameraAuthorizationStatus == .notDetermined {
-            requestCameraPermission()
-        } else {
-            openCameraPrivacySettings()
-        }
-    }
-
     private func refreshCameraState() {
         cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
         refreshAvailableCameras()
@@ -132,28 +93,4 @@ struct MirrorSettingsView: View {
         availableCameras = MirrorManager.availableCameras()
     }
 
-    private func requestCameraPermission() {
-        guard !requestingCameraPermission else { return }
-
-        Task {
-            requestingCameraPermission = true
-            let granted = await AVCaptureDevice.requestAccess(for: .video)
-            await MainActor.run {
-                cameraAuthorizationStatus = granted
-                    ? .authorized
-                    : AVCaptureDevice.authorizationStatus(for: .video)
-                requestingCameraPermission = false
-                refreshAvailableCameras()
-            }
-        }
-    }
-
-    private func openCameraPrivacySettings() {
-        guard let url = URL(
-            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
-        ) else {
-            return
-        }
-        NSWorkspace.shared.open(url)
-    }
 }

--- a/trace/Views/Settings/PermissionsSettingsView.swift
+++ b/trace/Views/Settings/PermissionsSettingsView.swift
@@ -1,0 +1,347 @@
+//
+//  PermissionsSettingsView.swift
+//  trace
+//
+
+import AppKit
+import AVFoundation
+import EventKit
+import Speech
+import SwiftUI
+
+private enum TracePermission {
+    case calendar
+    case camera
+    case microphone
+    case speechRecognition
+}
+
+struct PermissionsSettingsView: View {
+    @ObservedObject private var permissionManager = PermissionManager.shared
+    @ObservedObject private var settingsManager = SettingsManager.shared
+
+    @State private var accessibilityTrusted = AXIsProcessTrusted()
+    @State private var calendarAuthorizationStatus = EKEventStore.authorizationStatus(for: .event)
+    @State private var cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+    @State private var microphoneAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+    @State private var speechRecognitionAuthorizationStatus = SFSpeechRecognizer.authorizationStatus()
+    @State private var requestingPermission: TracePermission?
+
+    var body: some View {
+        NativeSettingsPane {
+            NativeSettingsSection("System Control") {
+                PermissionRow(
+                    title: "Accessibility",
+                    subtitle: "Lets Trace inspect and arrange other apps’ windows, search their menu items, and paste dictated text into the active app.",
+                    icon: "accessibility",
+                    status: accessibilityTrusted ? .granted : .denied,
+                    action: openAccessibilitySettings,
+                    buttonTitle: "Open Settings"
+                )
+
+                NativeSettingsDivider()
+
+                PermissionRow(
+                    title: "Automation",
+                    subtitle: "Lets Trace send Apple events to System Events for appearance commands and to Calendar when opening an event. macOS manages each target separately.",
+                    icon: "gearshape.2",
+                    status: .managedInSettings,
+                    action: { openPrivacySettings("Privacy_Automation") },
+                    buttonTitle: "Open Settings"
+                )
+            } footer: {
+                Text("Accessibility is required for window management and inserting dictation. Automation is requested only when you use a feature that controls another macOS app or service.")
+            }
+
+            NativeSettingsSection("Search & Events") {
+                PermissionRow(
+                    title: "Calendar",
+                    subtitle: "Lets Trace read event titles, times, and calendar names so upcoming events can appear in launcher search. Calendar data stays on your Mac.",
+                    icon: "calendar",
+                    status: calendarPermissionStatus,
+                    action: handleCalendarPermission,
+                    buttonTitle: buttonTitle(for: calendarPermissionStatus)
+                )
+            }
+
+            NativeSettingsSection("Mirror") {
+                PermissionRow(
+                    title: "Camera",
+                    subtitle: "Used only for the live local Mirror preview. Trace does not record, save, or send camera video.",
+                    icon: "video",
+                    status: cameraPermissionStatus,
+                    action: handleCameraPermission,
+                    buttonTitle: buttonTitle(for: cameraPermissionStatus)
+                )
+            }
+
+            NativeSettingsSection("Dictation") {
+                PermissionRow(
+                    title: "Microphone",
+                    subtitle: "Captures audio only while you hold the push-to-talk hotkey. Trace does not save the audio.",
+                    icon: "mic",
+                    status: microphonePermissionStatus,
+                    action: handleMicrophonePermission,
+                    buttonTitle: buttonTitle(for: microphonePermissionStatus)
+                )
+
+                NativeSettingsDivider()
+
+                PermissionRow(
+                    title: "Speech Recognition",
+                    subtitle: "Uses Apple’s on-device speech recognition and downloaded language assets to turn dictation into text. Trace does not store transcripts.",
+                    icon: "waveform",
+                    status: speechRecognitionPermissionStatus,
+                    action: handleSpeechRecognitionPermission,
+                    buttonTitle: buttonTitle(for: speechRecognitionPermissionStatus)
+                )
+            } footer: {
+                Text("All permissions are optional. Features that rely on a permission remain unavailable until access is granted.")
+            }
+        }
+        .onAppear(perform: refreshPermissions)
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshPermissions()
+        }
+    }
+
+    private var calendarPermissionStatus: PermissionStatus {
+        if requestingPermission == .calendar { return .checking }
+        if calendarAuthorizationStatus == .fullAccess { return .granted }
+        if calendarAuthorizationStatus == .notDetermined { return .notDetermined }
+        return .denied
+    }
+
+    private var cameraPermissionStatus: PermissionStatus {
+        permissionStatus(
+            for: cameraAuthorizationStatus,
+            isRequesting: requestingPermission == .camera
+        )
+    }
+
+    private var microphonePermissionStatus: PermissionStatus {
+        permissionStatus(
+            for: microphoneAuthorizationStatus,
+            isRequesting: requestingPermission == .microphone
+        )
+    }
+
+    private var speechRecognitionPermissionStatus: PermissionStatus {
+        if requestingPermission == .speechRecognition { return .checking }
+        switch speechRecognitionAuthorizationStatus {
+        case .authorized:
+            return .granted
+        case .notDetermined:
+            return .notDetermined
+        case .denied, .restricted:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
+    private func permissionStatus(
+        for status: AVAuthorizationStatus,
+        isRequesting: Bool
+    ) -> PermissionStatus {
+        if isRequesting { return .checking }
+        switch status {
+        case .authorized:
+            return .granted
+        case .notDetermined:
+            return .notDetermined
+        case .denied, .restricted:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
+    private func buttonTitle(for status: PermissionStatus) -> String {
+        status == .notDetermined ? "Request Permission" : "Open Settings"
+    }
+
+    private func handleCalendarPermission() {
+        refreshPermissions()
+        guard calendarAuthorizationStatus == .notDetermined else {
+            openPrivacySettings("Privacy_Calendars")
+            return
+        }
+
+        Task {
+            requestingPermission = .calendar
+            let granted = await permissionManager.requestCalendarPermissions()
+            if granted {
+                settingsManager.updateCalendarSearchEnabled(true)
+            }
+            requestingPermission = nil
+            refreshPermissions()
+        }
+    }
+
+    private func handleCameraPermission() {
+        refreshPermissions()
+        guard cameraAuthorizationStatus == .notDetermined else {
+            openPrivacySettings("Privacy_Camera")
+            return
+        }
+
+        Task {
+            requestingPermission = .camera
+            _ = await AVCaptureDevice.requestAccess(for: .video)
+            requestingPermission = nil
+            refreshPermissions()
+        }
+    }
+
+    private func handleMicrophonePermission() {
+        refreshPermissions()
+        guard microphoneAuthorizationStatus == .notDetermined else {
+            permissionManager.openMicrophonePrivacySettings()
+            return
+        }
+
+        Task {
+            requestingPermission = .microphone
+            _ = await permissionManager.requestMicrophonePermission()
+            requestingPermission = nil
+            refreshPermissions()
+        }
+    }
+
+    private func handleSpeechRecognitionPermission() {
+        refreshPermissions()
+        guard speechRecognitionAuthorizationStatus == .notDetermined else {
+            permissionManager.openSpeechRecognitionPrivacySettings()
+            return
+        }
+
+        Task {
+            requestingPermission = .speechRecognition
+            _ = await permissionManager.requestSpeechRecognitionPermission()
+            requestingPermission = nil
+            refreshPermissions()
+        }
+    }
+
+    private func refreshPermissions() {
+        accessibilityTrusted = AXIsProcessTrusted()
+        calendarAuthorizationStatus = EKEventStore.authorizationStatus(for: .event)
+        cameraAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        microphoneAuthorizationStatus = permissionManager.microphoneAuthorizationStatus
+        speechRecognitionAuthorizationStatus = permissionManager.speechRecognitionAuthorizationStatus
+    }
+
+    private func openAccessibilitySettings() {
+        openPrivacySettings("Privacy_Accessibility")
+    }
+
+    private func openPrivacySettings(_ pane: String) {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?\(pane)"
+        ) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}
+
+enum PermissionStatus {
+    case granted
+    case denied
+    case notDetermined
+    case checking
+    case managedInSettings
+
+    var color: Color {
+        switch self {
+        case .granted:
+            return .green
+        case .denied:
+            return .orange
+        case .notDetermined, .checking, .managedInSettings:
+            return .secondary
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .granted:
+            return "checkmark.circle.fill"
+        case .denied:
+            return "exclamationmark.triangle.fill"
+        case .notDetermined:
+            return "questionmark.circle.fill"
+        case .checking:
+            return "clock"
+        case .managedInSettings:
+            return "gearshape.fill"
+        }
+    }
+
+    var statusText: String {
+        switch self {
+        case .granted:
+            return "Granted"
+        case .denied:
+            return "Not Granted"
+        case .notDetermined:
+            return "Not Requested"
+        case .checking:
+            return "Checking..."
+        case .managedInSettings:
+            return "Managed in Settings"
+        }
+    }
+}
+
+struct PermissionRow: View {
+    let title: String
+    let subtitle: String
+    let icon: String
+    let status: PermissionStatus
+    let action: () -> Void
+    let buttonTitle: String
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(size: 13))
+
+                Text(subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 16)
+
+            VStack(alignment: .trailing, spacing: 4) {
+                HStack(spacing: 4) {
+                    Image(systemName: status.icon)
+                        .font(.system(size: 12))
+                        .foregroundStyle(status.color)
+
+                    Text(status.statusText)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(status.color)
+                }
+
+                if status != .checking {
+                    Button(buttonTitle, action: action)
+                        .font(.system(size: 11))
+                        .buttonStyle(.link)
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 9)
+        .frame(minHeight: 66)
+    }
+}

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -11,10 +11,10 @@ import Carbon
 
 enum TraceSettingsSection: String, CaseIterable, Identifiable {
     case general
+    case windowHotkeys
     case mirror
     case dictation
     case caffeinate
-    case windowHotkeys
     case appHotkeys
     case quickLinks
     case backupSync

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -126,7 +126,7 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
 
 private enum SettingsLayout {
     static let contentMaxWidth: CGFloat = 620
-    static let headerTopInset: CGFloat = 4
+    static let headerTopInset: CGFloat = 2
     static let contentTopInset: CGFloat = 12
     static let detailHorizontalInset: CGFloat = 18
     static let sidebarWidth: CGFloat = 215

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -11,8 +11,8 @@ import Carbon
 
 enum TraceSettingsSection: String, CaseIterable, Identifiable {
     case general
-    case windowHotkeys
     case permissions
+    case windowHotkeys
     case mirror
     case dictation
     case caffeinate

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -12,6 +12,7 @@ import Carbon
 enum TraceSettingsSection: String, CaseIterable, Identifiable {
     case general
     case windowHotkeys
+    case permissions
     case mirror
     case dictation
     case caffeinate
@@ -26,6 +27,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         switch self {
         case .general:
             return "General"
+        case .permissions:
+            return "Permissions"
         case .mirror:
             return "Mirror"
         case .dictation:
@@ -48,7 +51,9 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
     var subtitle: String {
         switch self {
         case .general:
-            return "Permissions, startup, appearance, and search"
+            return "Startup, appearance, and search"
+        case .permissions:
+            return "Privacy access used by Trace features"
         case .mirror:
             return "Camera access and preview preferences"
         case .dictation:
@@ -72,6 +77,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         switch self {
         case .general:
             return "gearshape"
+        case .permissions:
+            return "hand.raised"
         case .mirror:
             return "video"
         case .dictation:
@@ -95,6 +102,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         switch self {
         case .general:
             return Color(nsColor: .systemGray)
+        case .permissions:
+            return Color(nsColor: .systemYellow)
         case .mirror:
             return Color(nsColor: .systemTeal)
         case .dictation:
@@ -183,6 +192,8 @@ struct SettingsView: View {
             CaffeinateSettingsView()
         case .windowHotkeys:
             WindowManagementSettingsView()
+        case .permissions:
+            PermissionsSettingsView()
         case .appHotkeys:
             AppHotkeysSettingsView()
         case .quickLinks:

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -349,14 +349,11 @@ private struct SettingsSidebarRow: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 8) {
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(section.iconColor)
+                Image(systemName: section.systemImage)
+                    .font(.system(size: 15, weight: .medium))
+                    .symbolRenderingMode(.monochrome)
+                    .foregroundStyle(section.iconColor)
                     .frame(width: 22, height: 22)
-                    .overlay(
-                        Image(systemName: section.systemImage)
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.white)
-                    )
 
                 Text(section.title)
                     .font(.system(size: 13, weight: isSelected ? .semibold : .regular))

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -39,25 +39,6 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         }
     }
 
-    var tabTitle: String {
-        switch self {
-        case .general:
-            return "General"
-        case .dictation:
-            return "Dictation"
-        case .caffeinate:
-            return "Keep Awake"
-        case .windowHotkeys:
-            return "Windows"
-        case .appHotkeys:
-            return "Apps"
-        case .quickLinks:
-            return "Links"
-        case .about:
-            return "About"
-        }
-    }
-
     var subtitle: String {
         switch self {
         case .general:
@@ -120,6 +101,7 @@ private enum SettingsLayout {
     static let contentMaxWidth: CGFloat = 620
     static let detailTopInset: CGFloat = 18
     static let detailHorizontalInset: CGFloat = 18
+    static let sidebarWidth: CGFloat = 215
 }
 
 struct SettingsView: View {
@@ -140,11 +122,15 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            SettingsTopTabBar(selection: $selectedSection)
+        HStack(spacing: 0) {
+            SettingsSidebar(selection: $selectedSection)
 
-            selectedSectionView
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            VStack(spacing: 0) {
+                SettingsDetailHeader(section: selectedSection)
+
+                selectedSectionView
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         }
         .background(Color(nsColor: .windowBackgroundColor))
         .frame(
@@ -288,44 +274,37 @@ struct SettingsView: View {
     }
 }
 
-private struct SettingsTopTabBar: View {
+private struct SettingsSidebar: View {
     @Binding var selection: TraceSettingsSection
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
-        VStack(spacing: 0) {
-            GeometryReader { proxy in
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 4) {
-                        ForEach(TraceSettingsSection.allCases) { section in
-                            SettingsTopTabButton(
-                                section: section,
-                                isSelected: selection == section
-                            ) {
-                                selection = section
-                            }
-                        }
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 2) {
+                ForEach(TraceSettingsSection.allCases) { section in
+                    SettingsSidebarRow(
+                        section: section,
+                        isSelected: selection == section
+                    ) {
+                        selection = section
                     }
-                    .padding(.horizontal, 14)
-                    .padding(.top, 8)
-                    .padding(.bottom, 8)
-                    .frame(minWidth: proxy.size.width, alignment: .center)
                 }
             }
-            .frame(height: 68)
-
-            Rectangle()
-                .fill(colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.10))
-                .frame(height: 1)
+            .padding(.horizontal, 10)
+            .padding(.top, 10)
+            .padding(.bottom, 12)
         }
-        .background(
-            Rectangle()
-                .fill(Color(nsColor: .windowBackgroundColor))
-        )
+        .frame(width: SettingsLayout.sidebarWidth)
+        .frame(maxHeight: .infinity)
+        .background(sidebarBackground)
+    }
+
+    private var sidebarBackground: Color {
+        colorScheme == .dark ? Color.white.opacity(0.035) : Color.black.opacity(0.03)
     }
 }
 
-private struct SettingsTopTabButton: View {
+private struct SettingsSidebarRow: View {
     let section: TraceSettingsSection
     let isSelected: Bool
     let action: () -> Void
@@ -336,29 +315,31 @@ private struct SettingsTopTabButton: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(spacing: 5) {
-                Image(systemName: section.systemImage)
-                    .font(.system(size: 24, weight: .semibold))
-                    .symbolRenderingMode(.hierarchical)
-                    .foregroundStyle(isSelected ? traceTheme.accentForegroundSecondary : section.iconColor)
-                    .frame(width: 30, height: 28)
+            HStack(spacing: 8) {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(section.iconColor)
+                    .frame(width: 22, height: 22)
+                    .overlay(
+                        Image(systemName: section.systemImage)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.white)
+                    )
 
-                Text(section.tabTitle)
-                    .font(.system(size: 10.5, weight: isSelected ? .semibold : .medium))
+                Text(section.title)
+                    .font(.system(size: 13, weight: isSelected ? .semibold : .regular))
                     .foregroundStyle(textColor)
                     .lineLimit(1)
                     .minimumScaleFactor(0.86)
+
+                Spacer(minLength: 0)
             }
-            .frame(width: 78, height: 52)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
             .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
                     .fill(backgroundFill)
             )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(isSelected ? traceTheme.accentBorder : Color.primary.opacity(0.08), lineWidth: 1)
-            )
-            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(Text(section.title))
@@ -368,9 +349,9 @@ private struct SettingsTopTabButton: View {
 
     private var textColor: Color {
         if isSelected {
-            return colorScheme == .dark ? Color.white.opacity(0.92) : Color.black.opacity(0.84)
+            return colorScheme == .dark ? Color.white.opacity(0.94) : Color.black.opacity(0.86)
         }
-        return colorScheme == .dark ? Color.white.opacity(0.76) : Color.black.opacity(0.66)
+        return colorScheme == .dark ? Color.white.opacity(0.78) : Color.black.opacity(0.7)
     }
 
     private var backgroundFill: Color {
@@ -385,6 +366,33 @@ private struct SettingsTopTabButton: View {
 
     private var hoverFill: Color {
         colorScheme == .dark ? Color.white.opacity(0.055) : Color.black.opacity(0.045)
+    }
+}
+
+private struct SettingsDetailHeader: View {
+    let section: TraceSettingsSection
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(section.title)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(.primary)
+
+                Text(section.subtitle)
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, SettingsLayout.detailHorizontalInset)
+            .padding(.top, 10)
+            .padding(.bottom, 12)
+
+            Rectangle()
+                .fill(colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.10))
+                .frame(height: 1)
+        }
     }
 }
 

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -11,6 +11,7 @@ import Carbon
 
 enum TraceSettingsSection: String, CaseIterable, Identifiable {
     case general
+    case mirror
     case dictation
     case caffeinate
     case windowHotkeys
@@ -24,6 +25,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         switch self {
         case .general:
             return "General"
+        case .mirror:
+            return "Mirror"
         case .dictation:
             return "Dictation"
         case .caffeinate:
@@ -43,6 +46,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         switch self {
         case .general:
             return "Permissions, startup, appearance, and backups"
+        case .mirror:
+            return "Camera access and preview preferences"
         case .dictation:
             return "Push-to-talk offline dictation"
         case .caffeinate:
@@ -62,6 +67,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         switch self {
         case .general:
             return "gearshape"
+        case .mirror:
+            return "video"
         case .dictation:
             return "waveform.and.mic"
         case .caffeinate:
@@ -81,6 +88,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
         switch self {
         case .general:
             return Color(nsColor: .systemGray)
+        case .mirror:
+            return Color(nsColor: .systemTeal)
         case .dictation:
             return Color(nsColor: .systemRed)
         case .caffeinate:
@@ -157,6 +166,8 @@ struct SettingsView: View {
                 onHotkeyRecord: handleHotkeyRecord,
                 onHotkeyReset: handleHotkeyReset
             )
+        case .mirror:
+            MirrorSettingsView()
         case .dictation:
             DictationSettingsView()
         case .caffeinate:

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -126,7 +126,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
 
 private enum SettingsLayout {
     static let contentMaxWidth: CGFloat = 620
-    static let detailTopInset: CGFloat = 18
+    static let headerTopInset: CGFloat = 4
+    static let contentTopInset: CGFloat = 12
     static let detailHorizontalInset: CGFloat = 18
     static let sidebarWidth: CGFloat = 215
 }
@@ -349,11 +350,15 @@ private struct SettingsSidebarRow: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 8) {
-                Image(systemName: section.systemImage)
-                    .font(.system(size: 15, weight: .medium))
-                    .symbolRenderingMode(.monochrome)
-                    .foregroundStyle(section.iconColor)
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(iconBackgroundFill)
                     .frame(width: 22, height: 22)
+                    .overlay {
+                        Image(systemName: section.systemImage)
+                            .font(.system(size: 13, weight: .medium))
+                            .symbolRenderingMode(.monochrome)
+                            .foregroundStyle(section.iconColor)
+                    }
 
                 Text(section.title)
                     .font(.system(size: 13, weight: isSelected ? .semibold : .regular))
@@ -382,6 +387,10 @@ private struct SettingsSidebarRow: View {
             return colorScheme == .dark ? Color.white.opacity(0.94) : Color.black.opacity(0.86)
         }
         return colorScheme == .dark ? Color.white.opacity(0.78) : Color.black.opacity(0.7)
+    }
+
+    private var iconBackgroundFill: Color {
+        colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.06)
     }
 
     private var backgroundFill: Color {
@@ -416,7 +425,7 @@ private struct SettingsDetailHeader: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, SettingsLayout.detailHorizontalInset)
-            .padding(.top, 10)
+            .padding(.top, SettingsLayout.headerTopInset)
             .padding(.bottom, 12)
 
             Rectangle()
@@ -443,11 +452,12 @@ struct NativeSettingsPane<Content: View>: View {
                 content
             }
             .padding(.horizontal, SettingsLayout.detailHorizontalInset)
-            .padding(.top, SettingsLayout.detailTopInset)
+            .padding(.top, SettingsLayout.contentTopInset)
             .padding(.bottom, 16)
             .frame(maxWidth: SettingsLayout.contentMaxWidth, alignment: .topLeading)
             .frame(maxWidth: .infinity, alignment: .top)
         }
+        .contentMargins(.top, 0, for: .scrollContent)
         .scrollContentBackground(.hidden)
         .background(Color(nsColor: .windowBackgroundColor))
     }

--- a/trace/Views/SettingsView.swift
+++ b/trace/Views/SettingsView.swift
@@ -17,6 +17,7 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
     case windowHotkeys
     case appHotkeys
     case quickLinks
+    case backupSync
     case about
 
     var id: String { rawValue }
@@ -37,6 +38,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
             return "Application Hotkeys"
         case .quickLinks:
             return "Quick Links"
+        case .backupSync:
+            return "Backup & Sync"
         case .about:
             return "About"
         }
@@ -45,7 +48,7 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
     var subtitle: String {
         switch self {
         case .general:
-            return "Permissions, startup, appearance, and backups"
+            return "Permissions, startup, appearance, and search"
         case .mirror:
             return "Camera access and preview preferences"
         case .dictation:
@@ -58,6 +61,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
             return "Global shortcuts for launching apps"
         case .quickLinks:
             return "Folders, files, and web links in search"
+        case .backupSync:
+            return "Import, export, and remote synchronization"
         case .about:
             return "Version, data, and maintenance"
         }
@@ -79,6 +84,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
             return "app.badge"
         case .quickLinks:
             return "link"
+        case .backupSync:
+            return "arrow.triangle.2.circlepath"
         case .about:
             return "info.circle"
         }
@@ -100,6 +107,8 @@ enum TraceSettingsSection: String, CaseIterable, Identifiable {
             return Color(nsColor: .systemOrange)
         case .quickLinks:
             return Color(nsColor: .systemGreen)
+        case .backupSync:
+            return Color(nsColor: .systemIndigo)
         case .about:
             return Color(nsColor: .systemPurple)
         }
@@ -178,6 +187,8 @@ struct SettingsView: View {
             AppHotkeysSettingsView()
         case .quickLinks:
             QuickLinksSettingsView()
+        case .backupSync:
+            BackupSyncSettingsView()
         case .about:
             AboutSettingsView()
         }


### PR DESCRIPTION
## Summary

- replace the horizontal settings tab bar with a fixed-width sidebar
- add compact sidebar rows with section-specific icons and selection styling
- add a detail header that shows the active section title and description
- place Window Management immediately after General
- add a dedicated Permissions tab covering Accessibility, Automation, Calendar, Camera, Microphone, and Speech Recognition
- move permission controls out of General, Mirror, and Dictation and add clear descriptions of how each permission is used
- add a dedicated Mirror settings tab for camera selection
- add a dedicated Backup & Sync tab for local import/export and remote sync
- fix the Show Menu Bar Icon toggle applying the opposite visibility state

## Why

The sidebar layout makes all settings categories easier to scan and gives the content area a clearer hierarchy. Separating feature-specific controls reduces clutter in General and keeps related settings together. Centralizing privacy access makes Trace’s permission usage easier to understand and manage.

## Menu bar toggle root cause

The settings observer received the new published visibility value during willSet but then reread the old stored value. The observer now applies the emitted value directly on the main queue.

## Impact

Settings navigation now stays visible along the left side while the selected pane renders on the right. Permissions, Mirror camera controls, and backup/sync workflows have dedicated destinations. Existing feature behavior is preserved.

## Validation

- Debug macOS build with code signing disabled
- git diff --check