### PR TITLE
Fix background update reminders and layout recursion

### DIFF
--- a/trace/Core/AppDelegate.swift
+++ b/trace/Core/AppDelegate.swift
@@ -211,22 +211,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         menu.addItem(NSMenuItem.separator())
         
-        let updateTitle = availableUpdateVersion.map { "Update to Trace \($0)…" }
-            ?? "Check for Updates"
         let updateItem = NSMenuItem(
-            title: updateTitle,
+            title: "Check for Updates",
             action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
             keyEquivalent: ""
         )
         updateItem.target = updaterController
-        if availableUpdateVersion != nil {
-            updateItem.image = NSImage(
-                systemSymbolName: "arrow.down.circle.fill",
-                accessibilityDescription: updateTitle
-            )
-        }
         menu.addItem(updateItem)
         updateMenuItem = updateItem
+        updateUpdateMenuItemAppearance()
         
         // Report Issue
         let reportIssueItem = NSMenuItem(title: "Report Issue", action: #selector(reportIssue), keyEquivalent: "")
@@ -390,15 +383,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 fallbackSymbolName: "cup.and.saucer.fill",
                 accessibilityDescription: description
             )
-        } else if let availableUpdateVersion {
-            description = "Trace \(availableUpdateVersion) update available"
-            button.image = makeMenuBarSymbolImage(
-                named: "arrow.down.circle.fill",
-                fallbackSymbolName: "arrow.down.circle",
-                accessibilityDescription: description
-            )
         } else {
-            description = "Trace"
+            description = availableUpdateVersion.map {
+                "Trace \($0) update available"
+            } ?? "Trace"
             button.image = makeMenuBarImage(
                 named: "MenuBarIcon",
                 fallbackSymbolName: "filemenu.and.selection",
@@ -407,7 +395,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         button.image?.size = NSSize(width: 18, height: 18)
         button.image?.isTemplate = true
-        button.title = isCaffeinateActive && availableUpdateVersion != nil ? "•" : ""
+        button.title = availableUpdateVersion == nil ? "" : "•"
         if let availableUpdateVersion, isCaffeinateActive {
             button.toolTip = "Trace - Caffeinate is on · \(availableUpdateVersion) is available"
         } else if let availableUpdateVersion {
@@ -678,7 +666,9 @@ extension AppDelegate: SPUStandardUserDriverDelegate {
         _ update: SUAppcastItem,
         andInImmediateFocus immediateFocus: Bool
     ) -> Bool {
-        true
+        // Let Sparkle present its standard alert when the app already has the
+        // user's attention, or when the menu-bar reminder has no visible home.
+        immediateFocus || statusItem == nil
     }
 
     func standardUserDriverWillHandleShowingUpdate(

--- a/trace/Core/AppDelegate.swift
+++ b/trace/Core/AppDelegate.swift
@@ -44,14 +44,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var globalEventMonitor: Any?
     private var skipQuitConfirmation = false
     private var statusItem: NSStatusItem?
+    private weak var updateMenuItem: NSMenuItem?
     private var onboardingWindow: OnboardingWindow?
     private var settingsCancellable: AnyCancellable?
-    private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+    private var availableUpdateVersion: String?
+    private lazy var updaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: nil,
+        userDriverDelegate: self
+    )
     
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Ensure the app is truly a background app without dock icon
         NSApp.setActivationPolicy(.accessory)
         logger.notice("✅ Set app activation policy to .accessory (background app)")
+
+        // Start Sparkle even when the user has hidden Trace's menu bar icon.
+        _ = updaterController
         
         
         // Initialize unified hotkey registry first
@@ -130,6 +139,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let statusItem {
             NSStatusBar.system.removeStatusItem(statusItem)
             self.statusItem = nil
+            updateMenuItem = nil
         }
         
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -150,6 +160,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if let statusItem {
                 NSStatusBar.system.removeStatusItem(statusItem)
                 self.statusItem = nil
+                updateMenuItem = nil
                 logger.debug("Menu bar status item removed because setting is disabled")
             }
             return
@@ -200,10 +211,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         menu.addItem(NSMenuItem.separator())
         
-        // Check for Updates - Connect directly to Sparkle as per documentation
-        let updateItem = NSMenuItem(title: "Check for Updates", action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent: "")
+        let updateTitle = availableUpdateVersion.map { "Update to Trace \($0)…" }
+            ?? "Check for Updates"
+        let updateItem = NSMenuItem(
+            title: updateTitle,
+            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+            keyEquivalent: ""
+        )
         updateItem.target = updaterController
+        if availableUpdateVersion != nil {
+            updateItem.image = NSImage(
+                systemSymbolName: "arrow.down.circle.fill",
+                accessibilityDescription: updateTitle
+            )
+        }
         menu.addItem(updateItem)
+        updateMenuItem = updateItem
         
         // Report Issue
         let reportIssueItem = NSMenuItem(title: "Report Issue", action: #selector(reportIssue), keyEquivalent: "")
@@ -257,6 +280,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if let statusItem = statusItem {
                 NSStatusBar.system.removeStatusItem(statusItem)
                 self.statusItem = nil
+                updateMenuItem = nil
             }
         }
     }
@@ -355,15 +379,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard let button = statusItem?.button else { return }
 
         let isCaffeinateActive = caffeinateManager.isActive
-        let description = isCaffeinateActive ? "Trace Caffeinate On" : "Trace"
+        let description: String
 
         if isCaffeinateActive {
+            description = availableUpdateVersion.map {
+                "Trace Caffeinate On, version \($0) update available"
+            } ?? "Trace Caffeinate On"
             button.image = makeMenuBarSymbolImage(
                 named: "mug.fill",
                 fallbackSymbolName: "cup.and.saucer.fill",
                 accessibilityDescription: description
             )
+        } else if let availableUpdateVersion {
+            description = "Trace \(availableUpdateVersion) update available"
+            button.image = makeMenuBarSymbolImage(
+                named: "arrow.down.circle.fill",
+                fallbackSymbolName: "arrow.down.circle",
+                accessibilityDescription: description
+            )
         } else {
+            description = "Trace"
             button.image = makeMenuBarImage(
                 named: "MenuBarIcon",
                 fallbackSymbolName: "filemenu.and.selection",
@@ -372,7 +407,40 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         button.image?.size = NSSize(width: 18, height: 18)
         button.image?.isTemplate = true
-        button.toolTip = isCaffeinateActive ? "Trace - Caffeinate is on" : "Trace - Click to open launcher"
+        button.title = isCaffeinateActive && availableUpdateVersion != nil ? "•" : ""
+        if let availableUpdateVersion, isCaffeinateActive {
+            button.toolTip = "Trace - Caffeinate is on · \(availableUpdateVersion) is available"
+        } else if let availableUpdateVersion {
+            button.toolTip = "Trace \(availableUpdateVersion) is available"
+        } else {
+            button.toolTip = isCaffeinateActive
+                ? "Trace - Caffeinate is on"
+                : "Trace - Click to open launcher"
+        }
+    }
+
+    private func showUpdateReminder(for version: String) {
+        availableUpdateVersion = version
+        updateStatusItemAppearance()
+        updateUpdateMenuItemAppearance()
+    }
+
+    private func clearUpdateReminder() {
+        guard availableUpdateVersion != nil else { return }
+        availableUpdateVersion = nil
+        updateStatusItemAppearance()
+        updateUpdateMenuItemAppearance()
+    }
+
+    private func updateUpdateMenuItemAppearance() {
+        guard let updateMenuItem else { return }
+
+        let title = availableUpdateVersion.map { "Update to Trace \($0)…" }
+            ?? "Check for Updates"
+        updateMenuItem.title = title
+        updateMenuItem.image = availableUpdateVersion == nil
+            ? nil
+            : NSImage(systemSymbolName: "arrow.down.circle.fill", accessibilityDescription: title)
     }
 
     private func makeMenuBarImage(
@@ -599,4 +667,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.terminate(nil)
     }
     
+}
+
+extension AppDelegate: SPUStandardUserDriverDelegate {
+    var supportsGentleScheduledUpdateReminders: Bool {
+        true
+    }
+
+    func standardUserDriverShouldHandleShowingScheduledUpdate(
+        _ update: SUAppcastItem,
+        andInImmediateFocus immediateFocus: Bool
+    ) -> Bool {
+        true
+    }
+
+    func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool,
+        forUpdate update: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        guard !state.userInitiated else { return }
+        showUpdateReminder(for: update.displayVersionString)
+    }
+
+    func standardUserDriverDidReceiveUserAttention(forUpdate update: SUAppcastItem) {
+        clearUpdateReminder()
+    }
+
+    func standardUserDriverWillFinishUpdateSession() {
+        clearUpdateReminder()
+    }
 }

--- a/trace/Windows/MirrorWindow.swift
+++ b/trace/Windows/MirrorWindow.swift
@@ -389,7 +389,7 @@ private final class MirrorCloseButton: NSButton {
 
     override func layout() {
         super.layout()
-        updateAppearance()
+        updateLayerGeometry()
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -415,10 +415,11 @@ private final class MirrorCloseButton: NSButton {
         isBordered = false
         focusRingType = .none
 
+        updateLayerGeometry()
         updateAppearance()
     }
 
-    private func updateAppearance() {
+    private func updateLayerGeometry() {
         visualLayer.frame = NSRect(
             x: 0,
             y: 0,
@@ -426,6 +427,9 @@ private final class MirrorCloseButton: NSButton {
             height: bounds.height
         )
         visualLayer.cornerRadius = bounds.height / 2
+    }
+
+    private func updateAppearance() {
         visualLayer.backgroundColor = backgroundColor.cgColor
 
         let foregroundColor = NSColor.white.withAlphaComponent(isHighlighted ? 0.96 : 0.86)


### PR DESCRIPTION
## Summary

- implement Sparkle gentle scheduled-update reminders for Trace’s dockless background mode
- keep automatic checks running when the menu-bar icon is hidden
- show update availability through the existing status item without replacing a tracked menu
- preserve the Caffeinate indicator when an update is also pending
- keep `MirrorCloseButton.layout()` limited to layer geometry

## Why

Sparkle warned that scheduled update alerts could be missed in a background app without a gentle reminder. Trace now retains Sparkle’s standard alert behavior while adding a persistent menu-bar reminder when available.

AppKit also detected layout recursion because the Mirror close button updated its attributed title during `layout()`, which could invalidate intrinsic layout during the active pass. Appearance updates now happen only during setup and interaction-state changes.

## Validation

- `xcodebuild -quiet -project trace.xcodeproj -scheme trace -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- independent Claude Opus review followed by fixes for updater startup, combined update/Caffeinate state, and menu-tracking safety
- `git diff --cached --check`
